### PR TITLE
Establish consistent formatting in two-center code

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,8 @@ contributed to this package :
 
 * Bálint Aradi (University of Bremen)
 
+* Tammo van der Heide (University of Bremen)
+
 * Ben Hourahine (University of Strathclyde, UK)
 
 * Ziyang Hu (Hong Kong Quantum AI Lab Limited, HKU)

--- a/common/lib/accuracy.F90
+++ b/common/lib/accuracy.F90
@@ -3,13 +3,15 @@
 !! Not all routines use the string length specifications to set their character string lengths.
 module common_accuracy
 
+  use, intrinsic :: iso_fortran_env, only : real64
+
   implicit none
   private
 
   public :: dp, cp, sc, mc, lc
 
   !> precision of the real data type
-  integer, parameter :: dp = 8
+  integer, parameter :: dp = real64
 
   !> precision of the complex data type
   integer, parameter :: cp = dp

--- a/common/lib/fifo_real1.F90
+++ b/common/lib/fifo_real1.F90
@@ -1,14 +1,13 @@
 !> Implements fifo for rank 1 real (double precision) arrays.
 module common_fifo_real1
 
+  use common_accuracy, only : dp
   use common_fifobase, only : TFiFoBase, size
 
   implicit none
   private
 
   public :: TFiFoReal1
-
-  integer, parameter :: dp = kind(1.0d0)
 
 
   !> Extended data type.

--- a/common/lib/fifo_real2.F90
+++ b/common/lib/fifo_real2.F90
@@ -1,14 +1,13 @@
 !> Implements fifo for rank 2 real (double precision) arrays.
 module common_fifo_real2
 
+  use common_accuracy, only : dp
   use common_fifobase, only : TFiFoBase, size
 
   implicit none
   private
 
   public :: TFiFoReal2
-
-  integer, parameter :: dp = kind(1.0d0)
 
 
   !> Extended data type.

--- a/common/lib/taggedout.F90
+++ b/common/lib/taggedout.F90
@@ -89,7 +89,7 @@ contains
       nfield = 1
     end if
 
-    write (this%formInt, "('(', I2.2, 'I', I2.2, ')')") nfield, nchar
+    write(this%formInt, "('(', I2.2, 'I', I2.2, ')')") nfield, nchar
 
     write(this%formLogical, "('(40L2)')")
 

--- a/sktwocnt/lib/bisection.f90
+++ b/sktwocnt/lib/bisection.f90
@@ -1,7 +1,7 @@
 !> Contains routines to locate a value in an array using bisection.
 module bisection
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
 
   implicit none
   private
@@ -13,7 +13,7 @@ module bisection
     module procedure bisect_real
     module procedure bisect_int
   end interface bisect
-  
+
 contains
 
   !> Real case for bisection search to to find a point in an array xx(:)
@@ -23,15 +23,15 @@ contains
   !! \param x0 Value to locate ind for.
   !! \param ind Located element such that xx(ind) < x < xx(ind).
   pure subroutine bisect_real(xx, x0, ind, tol)
-    real(dp), intent(in)           :: xx(:), x0
-    integer,  intent(out)          :: ind
+    real(dp), intent(in) :: xx(:), x0
+    integer, intent(out) :: ind
     real(dp), intent(in), optional :: tol
-    
-    integer  :: nn
-    integer  :: ilower, iupper, icurr
+
+    integer :: nn
+    integer :: ilower, iupper, icurr
     real(dp) :: rTol      ! real tolerance
-    logical  :: ascending
-    
+    logical :: ascending
+
     nn = size(xx)
     if (nn == 0) then
       ind = 0
@@ -43,8 +43,8 @@ contains
     else
       rTol = epsilon(0.0_dp)
     end if
-    
-    if (x0  < xx(1) - rTol) then
+
+    if (x0 < xx(1) - rTol) then
       ind = 0
     else if (abs(x0 - xx(1)) <= rTol) then
       ind = 1
@@ -53,7 +53,7 @@ contains
     else if (x0 > xx(nn) + rTol) then
       ind = nn
     else
-      ascending = (xx(nn) >=  xx(1))
+      ascending = (xx(nn) >= xx(1))
       ilower = 0
       icurr = nn + 1
       do while ((icurr - ilower) > 1)
@@ -66,9 +66,8 @@ contains
       end do
       ind = ilower
     end if
-    
-  end subroutine bisect_real
 
+  end subroutine bisect_real
 
   !> Integer case for bisection search to to find a point in an array xx(:)
   !! between xx(1) and xx(size(xx)) such that element indexed ind is less than
@@ -93,16 +92,16 @@ contains
       ind = 0
     else if (x0 == xx(1)) then
       ind = 1
-    else if(x0 == xx(nn)) then
-      ind = nn -1
-    else if(x0 > xx(nn)) then
+    else if (x0 == xx(nn)) then
+      ind = nn - 1
+    else if (x0 > xx(nn)) then
       ind = nn
     else
       ilower = 0
       icurr = nn + 1
       do while ((icurr - ilower) > 1)
         iupper = (icurr + ilower) / 2
-        if((xx(nn) >= xx(1)) .eqv. (x0 >= xx(iupper)))then
+        if ((xx(nn) >= xx(1)) .eqv. (x0 >= xx(iupper))) then
           ilower = iupper
         else
           icurr = iupper

--- a/sktwocnt/lib/coordtrans.f90
+++ b/sktwocnt/lib/coordtrans.f90
@@ -1,6 +1,6 @@
 module coordtrans
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use common_constants
 
   implicit none
@@ -18,7 +18,7 @@ contains
     real(dp), intent(out) :: spheric(:)
     real(dp), intent(out) :: jacobi
 
-    real(dp), parameter :: rm = 1.5_dp;
+    real(dp), parameter :: rm = 1.5_dp; 
     real(dp) :: rtmp1, rtmp2
 
     !assert(size(c11) == 3)
@@ -33,7 +33,6 @@ contains
 
   end subroutine coordtrans_becke
 
-
   !> Transforms a 2 dimensional vector with coordinates in [-1,1] onto spherical
   !! coordinates (r, theta), using the Becke algorithm.
   !! \param crd11 2d coordinate vector, each coordinate in [-1,1].
@@ -45,7 +44,7 @@ contains
     real(dp), intent(out) :: spheric(:)
     real(dp), intent(out) :: jacobi
 
-    real(dp), parameter :: rm = 1.5_dp;
+    real(dp), parameter :: rm = 1.5_dp; 
     real(dp) :: rtmp1, rtmp2
 
     !assert(size(c11) == 2)
@@ -58,7 +57,6 @@ contains
     jacobi = 2.0_dp * rm**3 * rtmp1**2 / rtmp2**4
 
   end subroutine coordtrans_becke_12
-
 
   !> Transforms a 2 dimensional vector with coordinates in [-1,1] onto spherical
   !! coordinates (theta, phi), using the Becke algorithm.
@@ -79,7 +77,6 @@ contains
     jacobi = pi
 
   end subroutine coordtrans_becke_23
-  
 
   !> Transforms a 3 dimensional vector with coordinates in [-1,1] onto spherical
   !! coordinates, using the Ahlrichs algorithm.
@@ -93,7 +90,7 @@ contains
     real(dp), intent(out) :: jacobi
 
     real(dp), parameter :: zeta = 1.20_dp
-    real(dp) :: rr 
+    real(dp) :: rr
 
     !assert(size(c11) == 3)
     !assert(size(spheric) == 3)
@@ -105,8 +102,6 @@ contains
     jacobi = (zeta / log(2.0_dp)) / (1.0_dp - c11(1)) * rr * rr * pi
 
   end subroutine coordtrans_ahlrichs1
-
-
 
   !> Transforms a 3 dimensional vector with coordinates in [-1,1] onto spherical
   !! coordinates, using the Ahlrichs algorithm.
@@ -120,7 +115,7 @@ contains
     real(dp), intent(out) :: jacobi
 
     real(dp), parameter :: zeta = 1.20_dp
-    real(dp) :: rr 
+    real(dp) :: rr
 
     !assert(size(c11) == 3)
     !assert(size(spheric) == 3)
@@ -132,7 +127,6 @@ contains
     jacobi = (zeta / log(2.0_dp)) / (1.0_dp - c11(1)) * rr * rr
 
   end subroutine coordtrans_ahlrichs1_2d
-
 
   !> Transforms a 3 dimensional vector with coordinates in [-1,1] onto spherical
   !! coordinates, using the Ahlrichs algorithm.
@@ -164,8 +158,6 @@ contains
 
   end subroutine coordtrans_ahlrichs2
 
-
-
   !> Transforms a 3 dimensional vector with coordinates in [-1,1] onto spherical
   !! coordinates, using the Ahlrichs algorithm.
   !! \param c11 3d coordinate vector, each coordinate in [-1,1].
@@ -195,8 +187,6 @@ contains
         &+ 1.0_dp / (1.0_dp - c11(1))) * rr * rr
 
   end subroutine coordtrans_ahlrichs2_2d
-
-
 
   subroutine coordtrans_identity(c11, ctarget, jacobi)
     real(dp), intent(in) :: c11(:)

--- a/sktwocnt/lib/dftbxc.f90
+++ b/sktwocnt/lib/dftbxc.f90
@@ -1,7 +1,7 @@
 module dftxc
 
   use, intrinsic :: ieee_arithmetic
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use common_constants
 
   implicit none
@@ -40,10 +40,8 @@ contains
     end do
 
     deallocate(rs, rho)
-    
+
   end subroutine getxcpot_ldapw91
-
-
 
   subroutine getxcpot_ggapbe(rho4pi, absgr4pi, laplace4pi, gr_grabsgr4pi, xcpot)
     real(dp), intent(in) :: rho4pi(:)
@@ -71,7 +69,7 @@ contains
     rs = (3.0_dp / rho4pi)**(1.0_dp / 3.0_dp)
     zeta = 0.0_dp
     gg = 1.0_dp
-    alpha = (4.0_dp/(9.0_dp * pi))**(1.0_dp/3.0_dp)
+    alpha = (4.0_dp / (9.0_dp * pi))**(1.0_dp / 3.0_dp)
     ! Factors for the correlation routine
     fac = sqrt(pi / 4.0_dp * alpha * rs) / (2.0_dp * gg)
     tt = absgr * fac
@@ -92,11 +90,11 @@ contains
             &ec, vcup, vcdn)
         call exchange_pbe(rho(ii), ss(ii), u2(ii), v2(ii), 1, ex, vx)
         if (ieee_is_nan(vcup)) then
-          print *, "VCUP NAN", ii, rs(ii), tt(ii), uu(ii), vv(ii)
-          print *, ":", absgr(ii), gr_grabsgr(ii), laplace(ii)
+          print*,"VCUP NAN", ii, rs(ii), tt(ii), uu(ii), vv(ii)
+          print*,":", absgr(ii), gr_grabsgr(ii), laplace(ii)
           stop
         elseif (ieee_is_nan(vx)) then
-          print *, "VX NAN", ii
+          print*,"VX NAN", ii
           stop
         end if
         xcpot(ii) = vcup + vx
@@ -105,12 +103,10 @@ contains
 
     deallocate(rho, absgr, laplace, gr_grabsgr)
     deallocate(rs, fac, tt, uu, vv)
-     
+
   end subroutine getxcpot_ggapbe
 
-
-  
-  SUBROUTINE CORRELATION_PBE(RS,ZET,T,UU,VV,WW,igga,ec,vc1,vc2)
+  SUBROUTINE CORRELATION_PBE(RS, ZET, T, UU, VV, WW, igga, ec, vc1, vc2)
 
     !
     ! APART FROM COSMETICS THIS IS IN FACT BURKEs FORTRAN REFERENCE IMPLEMENTATION
@@ -118,7 +114,7 @@ contains
 
     ! This is the PBE and PW-LDA Correlation routine.
 
-    IMPLICIT REAL(8) (A-H,O-Z)
+    IMPLICIT REAL(8) (A - H, O - Z)
     !----------------------------------------------------------------------
     !  INPUT: RS=SEITZ RADIUS=(3/4pi rho)^(1/3)
     !       : ZET=RELATIVE SPIN POLARIZATION = (rhoup-rhodn)/rho
@@ -136,7 +132,7 @@ contains
     !        : dvcdn=nonlocal correction to vcdn
     !----------------------------------------------------------------------
     ! References:
-    ! [a] J.P.~Perdew, K.~Burke, and M.~Ernzerhof, 
+    ! [a] J.P.~Perdew, K.~Burke, and M.~Ernzerhof,
     !     {\sl Generalized gradient approximation made simple}, sub.
     !     to Phys. Rev.Lett. May 1996.
     ! [b] J. P. Perdew, K. Burke, and Y. Wang, {\sl Real-space cutoff
@@ -146,18 +142,18 @@ contains
     !----------------------------------------------------------------------
     !     bet=coefficient in gradient expansion for correlation, [a](4).
     integer :: igga
-    parameter(thrd=1.d0/3.d0,thrdm=-thrd,thrd2=2.d0*thrd)
-    parameter(GAM=0.5198420997897463295344212145565d0)
-    parameter(thrd4=4.d0*thrd, fzz=8.d0/(9.d0*GAM))
-    parameter(gamma=0.03109069086965489503494086371273d0)
-    parameter(bet=0.06672455060314922d0,delt=bet/gamma)
-    dimension u(6),p(6),s(6)
-    data u/ 0.03109070D0, 0.2137000D0, 7.5957000D0,&
-        &        3.58760000D0, 1.6382000D0, 0.4929400D0/
-    data p/ 0.01554535D0, 0.2054800D0,14.1189000D0,&
-        &        6.19770000D0, 3.3662000D0, 0.6251700D0/
-    data s/ 0.01688690D0, 0.1112500D0,10.3570000D0,&
-        &        3.62310000D0, 0.8802600D0, 0.4967100D0/
+    parameter(thrd=1._dp / 3._dp, thrdm=-thrd, thrd2=2._dp * thrd)
+    parameter(GAM=0.5198420997897463295344212145565_dp)
+    parameter(thrd4=4._dp * thrd, fzz=8._dp / (9._dp * GAM))
+    parameter(gamma=0.03109069086965489503494086371273_dp)
+    parameter(bet=0.06672455060314922_dp, delt=bet / gamma)
+    dimension u(6), p(6), s(6)
+    data u/0.03109070_dp, 0.2137000_dp, 7.5957000_dp,&
+        &        3.58760000_dp, 1.6382000_dp, 0.4929400_dp/
+    data p/0.01554535_dp, 0.2054800_dp, 14.1189000_dp,&
+        &        6.19770000_dp, 3.3662000_dp, 0.6251700_dp/
+    data s/0.01688690_dp, 0.1112500_dp, 10.3570000_dp,&
+        &        3.62310000_dp, 0.8802600_dp, 0.4967100_dp/
     !----------------------------------------------------------------------
     !     find LSD energy contributions, using [c](10) .
     !     EU=unpolarized LSD correlation energy , EURS=dEU/drs
@@ -167,123 +163,122 @@ contains
     !     construct ecl, using [c](8) .
     !
 
-    rtrs=dsqrt(rs)
-    Q0 = -2.D0*u(1)*(1.D0+u(2)*rtrs*rtrs)
-    Q1 = 2.D0*u(1)*rtrs*(u(3)+rtrs*(u(4)+rtrs*(u(5)+u(6)*rtrs)))
-    Q2 = DLOG(1.D0+1.D0/Q1)
-    Q3 = u(1)*(u(3)/rtrs+2.D0*u(4)+rtrs*(3.D0*u(5)+4.D0*u(6)*rtrs))
-    EU = Q0*Q2
-    EURS = -2.D0*u(1)*u(2)*Q2-Q0*Q3/(Q1*(1.d0+Q1))
-    Q0 = -2.D0*p(1)*(1.D0+p(2)*rtrs*rtrs)
-    Q1 = 2.D0*p(1)*rtrs*(p(3)+rtrs*(p(4)+rtrs*(p(5)+p(6)*rtrs)))
-    Q2 = DLOG(1.D0+1.D0/Q1)
-    Q3 = p(1)*(p(3)/rtrs+2.D0*p(4)+rtrs*(3.D0*p(5)+4.D0*p(6)*rtrs))
-    EP = Q0*Q2
-    EPRS = -2.D0*p(1)*p(2)*Q2-Q0*Q3/(Q1*(1.d0+Q1))
-    Q0 = -2.D0*s(1)*(1.D0+s(2)*rtrs*rtrs)
-    Q1 = 2.D0*s(1)*rtrs*(s(3)+rtrs*(s(4)+rtrs*(s(5)+s(6)*rtrs)))
-    Q2 = DLOG(1.D0+1.D0/Q1)
-    Q3 = s(1)*(s(3)/rtrs+2.D0*s(4)+rtrs*(3.D0*s(5)+4.D0*s(6)*rtrs))
-    ALFM = Q0*Q2
-    ALFRSM = -2.D0*s(1)*s(2)*Q2-Q0*Q3/(Q1*(1.d0+Q1))
+    rtrs = dsqrt(rs)
+    Q0 = -2._dp * u(1) * (1._dp + u(2) * rtrs * rtrs)
+    Q1 = 2._dp * u(1) * rtrs * (u(3) + rtrs * (u(4) + rtrs * (u(5) + u(6) * rtrs)))
+    Q2 = DLOG(1._dp + 1._dp / Q1)
+    Q3 = u(1) * (u(3) / rtrs + 2._dp * u(4) + rtrs * (3._dp * u(5) + 4._dp * u(6) * rtrs))
+    EU = Q0 * Q2
+    EURS = -2._dp * u(1) * u(2) * Q2 - Q0 * Q3 / (Q1 * (1._dp + Q1))
+    Q0 = -2._dp * p(1) * (1._dp + p(2) * rtrs * rtrs)
+    Q1 = 2._dp * p(1) * rtrs * (p(3) + rtrs * (p(4) + rtrs * (p(5) + p(6) * rtrs)))
+    Q2 = DLOG(1._dp + 1._dp / Q1)
+    Q3 = p(1) * (p(3) / rtrs + 2._dp * p(4) + rtrs * (3._dp * p(5) + 4._dp * p(6) * rtrs))
+    EP = Q0 * Q2
+    EPRS = -2._dp * p(1) * p(2) * Q2 - Q0 * Q3 / (Q1 * (1._dp + Q1))
+    Q0 = -2._dp * s(1) * (1._dp + s(2) * rtrs * rtrs)
+    Q1 = 2._dp * s(1) * rtrs * (s(3) + rtrs * (s(4) + rtrs * (s(5) + s(6) * rtrs)))
+    Q2 = DLOG(1._dp + 1._dp / Q1)
+    Q3 = s(1) * (s(3) / rtrs + 2._dp * s(4) + rtrs * (3._dp * s(5) + 4._dp * s(6) * rtrs))
+    ALFM = Q0 * Q2
+    ALFRSM = -2._dp * s(1) * s(2) * Q2 - Q0 * Q3 / (Q1 * (1._dp + Q1))
 
     Z4 = ZET**4
-    F=((1.D0+ZET)**THRD4+(1.D0-ZET)**THRD4-2.D0)/GAM
-    ECL= EU*(1.D0-F*Z4)+EP*F*Z4-ALFM*F*(1.D0-Z4)/FZZ
+    F = ((1._dp + ZET)**THRD4 + (1._dp - ZET)**THRD4 - 2._dp) / GAM
+    ECL = EU * (1._dp - F * Z4) + EP * F * Z4 - ALFM * F * (1._dp - Z4) / FZZ
     !----------------------------------------------------------------------
     !     LSD potential from [c](A1)
     !     ECRS = dEc/drs , ECZET=dEc/dzeta , FZ = dF/dzeta   [c](A2-A4)
     !
-    ECRS = EURS*(1.D0-F*Z4)+EPRS*F*Z4-ALFRSM*F*(1.D0-Z4)/FZZ
-    FZ = THRD4*((1.D0+ZET)**THRD-(1.D0-ZET)**THRD)/GAM
-    ECZET = 4.D0*(ZET**3)*F*(EP-EU+ALFM/FZZ)&
-        &        +FZ*(Z4*EP-Z4*EU-(1.D0-Z4)*ALFM/FZZ)
-    COMM = ECL -RS*ECRS/3.D0-ZET*ECZET
+    ECRS = EURS * (1._dp - F * Z4) + EPRS * F * Z4 - ALFRSM * F * (1._dp - Z4) / FZZ
+    FZ = THRD4 * ((1._dp + ZET)**THRD - (1._dp - ZET)**THRD) / GAM
+    ECZET = 4._dp * (ZET**3) * F * (EP - EU + ALFM / FZZ)&
+        &        + FZ * (Z4 * EP - Z4 * EU - (1._dp - Z4) * ALFM / FZZ)
+    COMM = ECL - RS * ECRS / 3._dp - ZET * ECZET
     VCUP = COMM + ECZET
     VCDN = COMM - ECZET
-    if(igga.eq.0)then
-      EC=ECL
-      VC1=VCUP
-      VC2=VCDN 
+    if (igga .eq. 0) then
+      EC = ECL
+      VC1 = VCUP
+      VC2 = VCDN
       return
-    endif
+    end if
     !----------------------------------------------------------------------
     !     PBE correlation energy
     !     G=phi(zeta), given after [a](3)
     !     DELT=bet/gamma , B=A of [a](8)
     !
-    G=((1.d0+ZET)**thrd2+(1.d0-ZET)**thrd2)/2.d0
+    G = ((1._dp + ZET)**thrd2 + (1._dp - ZET)**thrd2) / 2._dp
     G3 = G**3
-    PON=-ECL/(G3*gamma)
-    B = DELT/(DEXP(PON)-1.D0)
-    B2 = B*B
-    T2 = T*T
-    T4 = T2*T2
-    Q4 = 1.D0+B*T2
-    Q5 = 1.D0+B*T2+B2*T4
-    ECN= G3*(BET/DELT)*DLOG(1.D0+DELT*Q4*T2/Q5)
+    PON = -ECL / (G3 * gamma)
+    B = DELT / (DEXP(PON) - 1._dp)
+    B2 = B * B
+    T2 = T * T
+    T4 = T2 * T2
+    Q4 = 1._dp + B * T2
+    Q5 = 1._dp + B * T2 + B2 * T4
+    ECN = G3 * (BET / DELT) * DLOG(1._dp + DELT * Q4 * T2 / Q5)
     EC = ECL + ECN
     !----------------------------------------------------------------------
     !     ENERGY DONE. NOW THE POTENTIAL, using appendix E of [b].
     !
-    G4 = G3*G
-    T6 = T4*T2
-    RSTHRD = RS/3.D0
-    !      GZ=((1.d0+zet)**thirdm-(1.d0-zet)**thirdm)/3.d0
+    G4 = G3 * G
+    T6 = T4 * T2
+    RSTHRD = RS / 3._dp
+    !      GZ=((1._dp+zet)**thirdm-(1._dp-zet)**thirdm)/3._dp
     ! ckoe: hack thirdm never gets defined, but 1-1 should be zero anyway
-    GZ=0.0d0
-    FAC = DELT/B+1.D0
-    BG = -3.D0*B2*ECL*FAC/(BET*G4)
-    BEC = B2*FAC/(BET*G3)
-    Q8 = Q5*Q5+DELT*Q4*Q5*T2
-    Q9 = 1.D0+2.D0*B*T2
-    hB = -BET*G3*B*T6*(2.D0+B*T2)/Q8
-    hRS = -RSTHRD*hB*BEC*ECRS
-    FACT0 = 2.D0*DELT-6.D0*B
-    FACT1 = Q5*Q9+Q4*Q9*Q9
-    hBT = 2.D0*BET*G3*T4*((Q4*Q5*FACT0-DELT*FACT1)/Q8)/Q8
-    hRST = RSTHRD*T2*hBT*BEC*ECRS
-    hZ = 3.D0*GZ*ecn/G + hB*(BG*GZ+BEC*ECZET)
-    hT = 2.d0*BET*G3*Q9/Q8
-    hZT = 3.D0*GZ*hT/G+hBT*(BG*GZ+BEC*ECZET)
-    FACT2 = Q4*Q5+B*T2*(Q4*Q9+Q5)
-    FACT3 = 2.D0*B*Q5*Q9+DELT*FACT2
-    hTT = 4.D0*BET*G3*T*(2.D0*B/Q8-(Q9*FACT3/Q8)/Q8)
-    COMM = ECN+HRS+HRST+T2*HT/6.D0+7.D0*T2*T*HTT/6.D0
-    PREF = HZ-GZ*T2*HT/G
-    FACT5 = GZ*(2.D0*HT+T*HTT)/G
-    COMM = COMM-PREF*ZET-UU*HTT-VV*HT-WW*(HZT-FACT5)
+    GZ = 0.0_dp
+    FAC = DELT / B + 1._dp
+    BG = -3._dp * B2 * ECL * FAC / (BET * G4)
+    BEC = B2 * FAC / (BET * G3)
+    Q8 = Q5 * Q5 + DELT * Q4 * Q5 * T2
+    Q9 = 1._dp + 2._dp * B * T2
+    hB = -BET * G3 * B * T6 * (2._dp + B * T2) / Q8
+    hRS = -RSTHRD * hB * BEC * ECRS
+    FACT0 = 2._dp * DELT - 6._dp * B
+    FACT1 = Q5 * Q9 + Q4 * Q9 * Q9
+    hBT = 2._dp * BET * G3 * T4 * ((Q4 * Q5 * FACT0 - DELT * FACT1) / Q8) / Q8
+    hRST = RSTHRD * T2 * hBT * BEC * ECRS
+    hZ = 3._dp * GZ * ecn / G + hB * (BG * GZ + BEC * ECZET)
+    hT = 2._dp * BET * G3 * Q9 / Q8
+    hZT = 3._dp * GZ * hT / G + hBT * (BG * GZ + BEC * ECZET)
+    FACT2 = Q4 * Q5 + B * T2 * (Q4 * Q9 + Q5)
+    FACT3 = 2._dp * B * Q5 * Q9 + DELT * FACT2
+    hTT = 4._dp * BET * G3 * T * (2._dp * B / Q8 - (Q9 * FACT3 / Q8) / Q8)
+    COMM = ECN + HRS + HRST + T2 * HT / 6._dp + 7._dp * T2 * T * HTT / 6._dp
+    PREF = HZ - GZ * T2 * HT / G
+    FACT5 = GZ * (2._dp * HT + T * HTT) / G
+    COMM = COMM - PREF * ZET - UU * HTT - VV * HT - WW * (HZT - FACT5)
     DVCUP = COMM + PREF
     DVCDN = COMM - PREF
-    VC1 = VCUP + DVCUP 
+    VC1 = VCUP + DVCUP
     VC2 = VCDN + DVCDN
-    !	print*,'c igga is',dvcup
+    !        print*,'c igga is',dvcup
 
     RETURN
   END subroutine CORRELATION_PBE
 
-
-  subroutine exchange_pbe(rho,s,u,t,igga,EX,VX)
+  subroutine exchange_pbe(rho, s, u, t, igga, EX, VX)
 
     ! APART FROM COSMETICS THIS IS IN FACT BURKEs FORTRAN REFERENCE IMPLEMENTATION
 
     ! This is the PBE and PW-LDA Exchange routine.
 
-    implicit integer(4) (i-n)
-    implicit real(8) (a-h,o-z)
+    implicit integer(4) (i - n)
+    implicit real(8) (a - h, o - z)
 
-    parameter(thrd=1.d0/3.d0,thrd4=4.d0/3.d0)
-    parameter(pi=3.14159265358979323846264338327950d0)
-    parameter(ax=-0.738558766382022405884230032680836d0)
+    parameter(thrd=1._dp / 3._dp, thrd4=4._dp / 3._dp)
+    parameter(pi=3.14159265358979323846264338327950_dp)
+    parameter(ax=-0.738558766382022405884230032680836_dp)
 
-    parameter(um=0.21951d0,uk=0.8040d0,ul=um/uk)
+    parameter(um=0.21951_dp, uk=0.8040_dp, ul=um / uk)
 
-    parameter(ap=1.647127d0,bp=0.980118d0,cp=0.017399d0)
-    parameter(aq=1.523671d0,bq=0.367229d0,cq=0.011282d0)
-    parameter(ah=0.19645d0,bh=7.7956d0)
-    parameter(ahp=0.27430d0,bhp=0.15084d0,ahq=0.004d0)
-    parameter(a1=0.19645d0,a2=0.27430d0,a3=0.15084d0,a4=100.d0)
-    parameter(a=7.79560d0,b1=0.004d0,eps=1.d-15)
+    parameter(ap=1.647127_dp, bp=0.980118_dp, cp=0.017399_dp)
+    parameter(aq=1.523671_dp, bq=0.367229_dp, cq=0.011282_dp)
+    parameter(ah=0.19645_dp, bh=7.7956_dp)
+    parameter(ahp=0.27430_dp, bhp=0.15084_dp, ahq=0.004_dp)
+    parameter(a1=0.19645_dp, a2=0.27430_dp, a3=0.15084_dp, a4=100._dp)
+    parameter(a=7.79560_dp, b1=0.004_dp, eps=1.d-15)
 
     !----------------------------------------------------------------------
     !----------------------------------------------------------------------
@@ -294,7 +289,7 @@ contains
     !  INPUT U:  (GRAD rho)*GRAD(ABS(GRAD rho))/(rho**2 * (2*KF)**3)
     !  INPUT V: (LAPLACIAN rho)/(rho*(2*KF)**2)  (for U,V, see PW86(24))
     !  input igga:  (=0=>don't put in gradient corrections, just LDA)
-    !  OUTPUT:  EXCHANGE ENERGY PER ELECTRON (LOCAL: EXL, NONLOCAL: EXN, 
+    !  OUTPUT:  EXCHANGE ENERGY PER ELECTRON (LOCAL: EXL, NONLOCAL: EXN,
     !           TOTAL: EX) AND POTENTIAL (VX)
     !----------------------------------------------------------------------
     ! References:
@@ -304,47 +299,46 @@ contains
     !----------------------------------------------------------------------
     ! Formulas: e_x[unif]=ax*rho^(4/3)  [LDA]
     !           ax = -0.75*(3/pi)^(1/3)
-    !	    e_x[PBE]=e_x[unif]*FxPBE(s)
-    !	    FxPBE(s)=1+uk-uk/(1+ul*s*s)                 [a](13)
-    !           uk, ul defined after [a](13) 
+    !            e_x[PBE]=e_x[unif]*FxPBE(s)
+    !            FxPBE(s)=1+uk-uk/(1+ul*s*s)                 [a](13)
+    !           uk, ul defined after [a](13)
     !----------------------------------------------------------------------
     !----------------------------------------------------------------------
     !     construct LDA exchange energy density
 
-    exunif = ax*rho**thrd
-    if((igga.eq.0).or.(s.lt.eps))then
-      EXL=exunif
-      EXN=0.d0
-      EX=EXL+EXN
-      VX= exunif*thrd4
+    exunif = ax * rho**thrd
+    if ((igga .eq. 0) .or. (s .lt. eps)) then
+      EXL = exunif
+      EXN = 0._dp
+      EX = EXL + EXN
+      VX = exunif * thrd4
       return
-    endif
+    end if
     !----------------------------------------------------------------------
     !     construct GGA enhancement factor
     !     find first and second derivatives of f and:
-    !     fs=(1/s)*df/ds  and  fss=dfs/ds = (d2f/ds2 - (1/s)*df/ds)/s 
+    !     fs=(1/s)*df/ds  and  fss=dfs/ds = (d2f/ds2 - (1/s)*df/ds)/s
 
     !
     ! PBE enhancement factors checked against NRLMOL
     !
-    if(igga.eq.1)then
-      p0 =1.d0+ul*s**2
-      f  =1.d0+uk-uk/p0
-      fs =2.d0*uk*ul/p0**2
-      fss=-4.d0*ul*s*fs/p0
-    endif
+    if (igga .eq. 1) then
+      p0 = 1._dp + ul * s**2
+      f = 1._dp + uk - uk / p0
+      fs = 2._dp * uk * ul / p0**2
+      fss = -4._dp * ul * s * fs / p0
+    end if
 
     !
 
-    EXL= exunif
-    EXN= exunif*(f-1.0d0)
-    EX = EXL+EXN
+    EXL = exunif
+    EXN = exunif * (f - 1.0_dp)
+    EX = EXL + EXN
     !----------------------------------------------------------------------
-    !     energy done. calculate potential from [b](24) 
+    !     energy done. calculate potential from [b](24)
     !
-    VX = exunif*(thrd4*f-(u-thrd4*s**3)*fss-t*fs )
-    !	 print*,'e igga is',igga,vx,xunif*thrd4
-
+    VX = exunif * (thrd4 * f - (u - thrd4 * s**3) * fss - t * fs)
+    !         print*,'e igga is',igga,vx,xunif*thrd4
 
     RETURN
   END subroutine exchange_pbe

--- a/sktwocnt/lib/gridgenerator.f90
+++ b/sktwocnt/lib/gridgenerator.f90
@@ -1,6 +1,6 @@
 module gridgenerator
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use quadratures
 
   implicit none
@@ -11,59 +11,58 @@ contains
     type(quadrature), intent(in) :: quads(2)
     interface
       subroutine coordtrans(oldc, newc, jacobi)
-        use common_accuracy, only : dp
+        use common_accuracy, only: dp
         real(dp), intent(in) :: oldc(:)
         real(dp), intent(out) :: newc(:)
         real(dp), intent(out) :: jacobi
       end subroutine coordtrans
     end interface
-    real(dp), allocatable, intent(out) :: grid(:,:)
+    real(dp), allocatable, intent(out) :: grid(:, :)
     real(dp), allocatable, intent(out) :: weights(:)
 
     integer :: n1, n2, nn
     integer :: ind, i1, i2
     real(dp) :: coord(2), coordreal(2), jacobi
 
-    n1 = size(quads(1)%xx)
-    n2 = size(quads(2)%xx)
+    n1 = size(quads(1) % xx)
+    n2 = size(quads(2) % xx)
     nn = n1 * n2
     allocate(grid(nn, 2))
     allocate(weights(nn))
     ind = 1
     do i2 = 1, n2
-      coord(2) = quads(2)%xx(i2)
+      coord(2) = quads(2) % xx(i2)
       do i1 = 1, n1
-        coord(1) = quads(1)%xx(i1)
+        coord(1) = quads(1) % xx(i1)
         call coordtrans(coord, coordreal, jacobi)
         grid(ind, 1) = coordreal(1)
         grid(ind, 2) = coordreal(2)
-        weights(ind) = quads(1)%ww(i1) * quads(2)%ww(i2) * jacobi
+        weights(ind) = quads(1) % ww(i1) * quads(2) % ww(i2) * jacobi
         ind = ind + 1
       end do
     end do
-    
-  end subroutine gengrid1_12
 
+  end subroutine gengrid1_12
 
   subroutine gengrid2_12(quads, coordtrans, partition, partparams, dist,&
       & grid1, grid2, dots, weights)
     type(quadrature), intent(in) :: quads(2)
     interface
       subroutine coordtrans(oldc, newc, jacobi)
-        use common_accuracy, only : dp
+        use common_accuracy, only: dp
         real(dp), intent(in) :: oldc(:)
         real(dp), intent(out) :: newc(:)
         real(dp), intent(out) :: jacobi
       end subroutine coordtrans
       function partition(r1, r2, dist, params)
-        use common_accuracy, only : dp
+        use common_accuracy, only: dp
         real(dp), intent(in) :: r1, r2, dist, params(:)
         real(dp) :: partition
       end function partition
     end interface
     real(dp), intent(in) :: partparams(:)
     real(dp), intent(in) :: dist
-    real(dp), allocatable, intent(out) :: grid1(:,:), grid2(:,:)
+    real(dp), allocatable, intent(out) :: grid1(:, :), grid2(:, :)
     real(dp), allocatable, intent(out) :: dots(:), weights(:)
 
     integer :: n1, n2, nn
@@ -71,18 +70,18 @@ contains
     real(dp) :: coord(2), coordreal(2)
     real(dp) :: r1, theta1, r2a, r2b, theta2a, theta2b, rtmpa, rtmpb, jacobi
 
-    n1 = size(quads(1)%xx)
-    n2 = size(quads(2)%xx)
+    n1 = size(quads(1) % xx)
+    n2 = size(quads(2) % xx)
     nn = n1 * n2
-    allocate(grid1(2*nn, 2))
-    allocate(grid2(2*nn, 2))
-    allocate(dots(2*nn))
-    allocate(weights(2*nn))
+    allocate(grid1(2 * nn, 2))
+    allocate(grid2(2 * nn, 2))
+    allocate(dots(2 * nn))
+    allocate(weights(2 * nn))
     ind = 1
     do i2 = 1, n2
-      coord(2) = quads(2)%xx(i2)
+      coord(2) = quads(2) % xx(i2)
       do i1 = 1, n1
-        coord(1) = quads(1)%xx(i1)
+        coord(1) = quads(1) % xx(i1)
         call coordtrans(coord, coordreal, jacobi)
         r1 = coordreal(1)
         theta1 = coordreal(2)
@@ -100,25 +99,25 @@ contains
         rtmpb = max(rtmpb, -1.0_dp)
         theta2a = acos(rtmpa)
         theta2b = acos(rtmpb)
-        
+
         grid1(ind, 1) = r1
         grid1(ind, 2) = theta1
-        grid1(ind+nn, 1) = r2b
-        grid1(ind+nn, 2) = theta2b
+        grid1(ind + nn, 1) = r2b
+        grid1(ind + nn, 2) = theta2b
         grid2(ind, 1) = r2a
         grid2(ind, 2) = theta2a
-        grid2(ind+nn, 1) = r1
-        grid2(ind+nn, 2) = theta1
+        grid2(ind + nn, 1) = r1
+        grid2(ind + nn, 2) = theta1
         dots(ind) = cos(theta1 - theta2a)
-        dots(ind+nn) = cos(theta2b - theta1)
-        
-        rtmpa = quads(1)%ww(i1) * quads(2)%ww(i2) * jacobi
-        weights(ind) =  rtmpa * partition(r1, r2a, dist, partparams)
-        weights(ind+nn) = rtmpa * partition(r1, r2b, -dist, partparams)
+        dots(ind + nn) = cos(theta2b - theta1)
+
+        rtmpa = quads(1) % ww(i1) * quads(2) % ww(i2) * jacobi
+        weights(ind) = rtmpa * partition(r1, r2a, dist, partparams)
+        weights(ind + nn) = rtmpa * partition(r1, r2b, -dist, partparams)
         ind = ind + 1
       end do
     end do
-    
+
   end subroutine gengrid2_12
-  
+
 end module gridgenerator

--- a/sktwocnt/lib/gridorbital.f90
+++ b/sktwocnt/lib/gridorbital.f90
@@ -1,7 +1,7 @@
 !> Implements a grid-type orbital.
 module gridorbital
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use common_constants
   use bisection
   use interpolation
@@ -34,7 +34,7 @@ module gridorbital
   interface init
     module procedure gridorb_init
     module procedure gridorb2_init
-  end interface  
+  end interface
 
   interface destruct
     module procedure gridorb_destruct
@@ -72,26 +72,24 @@ contains
     !assert(size(values, dim=1) == 2)
     !assert(size(values, dim=2) > 0)
 
-    self%ngrid = size(rvals)
-    allocate(self%rvalues(self%ngrid))
-    allocate(self%fvalues(self%ngrid))
-    self%rvalues = rvals(:)
-    self%fvalues = fvals(:)
-    
+    self % ngrid = size(rvals)
+    allocate(self % rvalues(self % ngrid))
+    allocate(self % fvalues(self % ngrid))
+    self % rvalues = rvals(:)
+    self % fvalues = fvals(:)
+
   end subroutine gridorb_init
 
-  
   !> Destructs the instance.
   !! \param self instance.
   subroutine gridorb_destruct(self)
     type(gridorb), intent(inout) :: self
-    
-    deallocate(self%rvalues)
-    deallocate(self%fvalues)
-    
+
+    deallocate(self % rvalues)
+    deallocate(self % fvalues)
+
   end subroutine gridorb_destruct
 
-  
   !> Delivers the value of the orbital
   !! \param self instance.
   !! \param rr radius at which to calculate the value.
@@ -106,39 +104,37 @@ contains
 
     ! sanity check
     !if (self%ngrid < ninter + 1) then
-    !  write (*,*) "not enough points in the orbital grid!"
+    !  write(*,*) "not enough points in the orbital grid!"
     !  stop
     !end if
 
     ! Find position of the point
-    call bisect(self%rvalues, rr, ind, 1e-10_dp)
-    rmax = self%rvalues(self%ngrid) + distfudge
-    if (rr >=  rmax) then
+    call bisect(self % rvalues, rr, ind, 1e-10_dp)
+    rmax = self % rvalues(self % ngrid) + distfudge
+    if (rr >= rmax) then
       ! outside of the region -> 0
       rad = 0.0_dp
-    elseif (ind < self%ngrid) then
+    elseif (ind < self % ngrid) then
       ! before last gridpoint
-      iend = min(self%ngrid, ind + nrightinter)
+      iend = min(self % ngrid, ind + nrightinter)
       iend = max(iend, ninter)
       istart = iend - ninter + 1
-      rad = polyinter(self%rvalues(istart:iend), self%fvalues(istart:iend), rr)
+      rad = polyinter(self % rvalues(istart:iend), self % fvalues(istart:iend), rr)
     else
-      iend = self%ngrid
+      iend = self % ngrid
       istart = iend - ninter + 1
       ! calculate 1st und 2nd derivatives at the end
-      f1 = self%fvalues(iend)
-      f0 = polyinter(self%rvalues(istart:iend), self%fvalues(istart:iend), &
-          &self%rvalues(iend) - deltar)
-      f2 = polyinter(self%rvalues(istart:iend), self%fvalues(istart:iend), &
-          &self%rvalues(iend) + deltar)
+      f1 = self % fvalues(iend)
+      f0 = polyinter(self % rvalues(istart:iend), self % fvalues(istart:iend), &
+          &self % rvalues(iend) - deltar)
+      f2 = polyinter(self % rvalues(istart:iend), self % fvalues(istart:iend), &
+          &self % rvalues(iend) + deltar)
       f1p = (f2 - f0) / (2.0_dp * deltar)
       f1pp = (f2 + f0 - 2.0_dp * f1) / deltar**2
       rad = poly5zero(f1, f1p, f1pp, rr - rmax, -1.0_dp * distfudge)
     end if
-        
+
   end function gridorb_getvalue
-
-
 
   !> Initializes the grid orbital.
   !! \param self  initialised instance on exit.
@@ -155,32 +151,30 @@ contains
     !assert(size(values, dim=2) > 0)
 
     call init(orb, rvals, fvals)
-    self%ngrid = npoint
-    allocate(self%rvalues(self%ngrid))
-    allocate(self%fvalues(self%ngrid))
-    self%delta = pi / real(self%ngrid + 1, dp)
-    do ii = 1, self%ngrid
-      xx = cos(self%delta * real(ii, dp))
+    self % ngrid = npoint
+    allocate(self % rvalues(self % ngrid))
+    allocate(self % fvalues(self % ngrid))
+    self % delta = pi / real(self % ngrid + 1, dp)
+    do ii = 1, self % ngrid
+      xx = cos(self % delta * real(ii, dp))
       rr = (1.0_dp - xx) / (1.0_dp + xx)
-      self%rvalues(ii) = rr
-      self%fvalues(ii) = getvalue(orb, rr)
+      self % rvalues(ii) = rr
+      self % fvalues(ii) = getvalue(orb, rr)
     end do
-    self%rcut = self%rvalues(self%ngrid) + distfudge
+    self % rcut = self % rvalues(self % ngrid) + distfudge
     call destruct(orb)
-    
+
   end subroutine gridorb2_init
 
-  
   !> Destructs the instance.
   !! \param self instance.
   subroutine gridorb2_destruct(self)
     type(gridorb2), intent(inout) :: self
-    
-    deallocate(self%fvalues)
-    
+
+    deallocate(self % fvalues)
+
   end subroutine gridorb2_destruct
 
-  
   !> Delivers the value of the orbital
   !! \param self instance.
   !! \param rr radius at which to calculate the value.
@@ -194,40 +188,38 @@ contains
     real(dp) :: rmax, f0, f1, f2, f1p, f1pp
     real(dp) :: xx
 
-    if (rr > self%rcut) then
+    if (rr > self % rcut) then
       rad = 0.0_dp
     end if
     xx = (1.0_dp - rr) / (1.0_dp + rr)
-    ind = floor(acos(xx) / self%delta)
-    if (ind < self%ngrid) then
-      iend = min(self%ngrid, ind + nrightinter2)
+    ind = floor(acos(xx) / self % delta)
+    if (ind < self % ngrid) then
+      iend = min(self % ngrid, ind + nrightinter2)
       iend = max(iend, ninter2)
       istart = iend - ninter2 + 1
-      rad = polyinter(self%rvalues(istart:iend), self%fvalues(istart:iend), rr)
+      rad = polyinter(self % rvalues(istart:iend), self % fvalues(istart:iend), rr)
     else
-      iend = self%ngrid
+      iend = self % ngrid
       istart = iend - ninter2 + 1
       ! calculate 1st und 2nd derivatives at the end
-      f1 = self%fvalues(iend)
-      f0 = polyinter(self%rvalues(istart:iend), self%fvalues(istart:iend), &
-          &self%rvalues(iend) - deltar)
-      f2 = polyinter(self%rvalues(istart:iend), self%fvalues(istart:iend), &
-          &self%rvalues(iend) + deltar)
+      f1 = self % fvalues(iend)
+      f0 = polyinter(self % rvalues(istart:iend), self % fvalues(istart:iend), &
+          &self % rvalues(iend) - deltar)
+      f2 = polyinter(self % rvalues(istart:iend), self % fvalues(istart:iend), &
+          &self % rvalues(iend) + deltar)
       f1p = (f2 - f0) / (2.0_dp * deltar)
       f1pp = (f2 + f0 - 2.0_dp * f1) / deltar**2
       rad = poly5zero(f1, f1p, f1pp, rr - rmax, -1.0_dp * distfudge)
     end if
-      
-  end function gridorb2_getvalue
 
+  end function gridorb2_getvalue
 
   subroutine gridorb2_rescale(self, fac)
     type(gridorb2), intent(inout) :: self
     real(dp), intent(in) :: fac
 
-    self%fvalues = self%fvalues * fac
-    
-  end subroutine gridorb2_rescale
+    self % fvalues = self % fvalues * fac
 
+  end subroutine gridorb2_rescale
 
 end module gridorbital

--- a/sktwocnt/lib/interpolation.f90
+++ b/sktwocnt/lib/interpolation.f90
@@ -1,17 +1,15 @@
 !!* Contains routines for interpolation and extrapolation
 module interpolation
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
 
   implicit none
   private
 
   public :: poly5zero, spline3_free, polyinter
 
-
 contains
 
-  
   !! Returns the value of a polynomial of 5th degree at x.
   !! \param y0 Value of the polynom at x = dx.
   !! \param y0p Value of the 1st derivative at x = dx.
@@ -35,15 +33,13 @@ contains
 
     dx1 = y0p * dx
     dx2 = y0pp * dx * dx
-    dd =  10.0_dp * y0 - 4.0_dp * dx1 + 0.5_dp * dx2
+    dd = 10.0_dp * y0 - 4.0_dp * dx1 + 0.5_dp * dx2
     ee = -15.0_dp * y0 + 7.0_dp * dx1 - 1.0_dp * dx2
-    ff =   6.0_dp * y0 - 3.0_dp * dx1 + 0.5_dp * dx2
+    ff = 6.0_dp * y0 - 3.0_dp * dx1 + 0.5_dp * dx2
     xr = xx / dx
-    yy = ((ff*xr + ee)*xr + dd)*xr*xr*xr
+    yy = ((ff * xr + ee) * xr + dd) * xr * xr * xr
 
   end function poly5zero
-
-  
 
   !! Returns the value of a free spline at a certain point.
   !! \param y0 Function value at x = 0.
@@ -60,7 +56,7 @@ contains
   !!   x = 0 and its value agrees with the provided value at x = dx.
   !! \note If you want the value for a derivative, you have to query them
   !!   both.
- pure subroutine spline3_free(y0, y0p, y0pp, dx, ydx, xx, yy, yp, ypp)
+  pure subroutine spline3_free(y0, y0p, y0pp, dx, ydx, xx, yy, yp, ypp)
     real(dp), intent(in) :: y0
     real(dp), intent(in) :: y0p
     real(dp), intent(in) :: y0pp
@@ -79,18 +75,16 @@ contains
     bb = y0p
     cc = 0.5_dp * y0pp
     dx1 = 1.0_dp / dx
-    dd = (((ydx - y0)*dx1 - y0p)*dx1 - 0.5_dp*y0pp)*dx1
+    dd = (((ydx - y0) * dx1 - y0p) * dx1 - 0.5_dp * y0pp) * dx1
     if (present(yy)) then
-      yy = ((dd*xx + cc)*xx + bb)*xx + aa
+      yy = ((dd * xx + cc) * xx + bb) * xx + aa
     end if
     if (present(yp)) then
-      yp = (3.0_dp*dd*xx + 2.0_dp*cc)*xx + bb
+      yp = (3.0_dp * dd * xx + 2.0_dp * cc) * xx + bb
       ypp = 6.0_dp * dd * xx + 2.0_dp * cc
     end if
-    
-  end subroutine spline3_free
 
-  
+  end subroutine spline3_free
 
   !! Polynomial interpolation through given points
   !! \param xa x-coordinates of the fit points
@@ -130,14 +124,14 @@ contains
     icl = icl - 1
     do mm = 1, nn - 1
       do ii = 1, nn - mm
-        rtmp = xp(ii) - xp(ii+mm)
+        rtmp = xp(ii) - xp(ii + mm)
         !if (abs(rtmp) < epsilon(1.0_dp)) then
-          !write (*,*) "Polint failed"
-          !stop
+        !write(*,*) "Polint failed"
+        !stop
         !end if
-        rtmp = (cc(ii+1) - dd(ii)) / rtmp
+        rtmp = (cc(ii + 1) - dd(ii)) / rtmp
         cc(ii) = (xp(ii) - xx) * rtmp
-        dd(ii) = (xp(ii+mm) - xx) * rtmp
+        dd(ii) = (xp(ii + mm) - xx) * rtmp
       end do
       if (2 * icl < nn - mm) then
         dyy = cc(icl + 1)
@@ -149,6 +143,5 @@ contains
     end do
 
   end function polyinter
-      
 
 end module interpolation

--- a/sktwocnt/lib/partition.f90
+++ b/sktwocnt/lib/partition.f90
@@ -1,13 +1,12 @@
 !> Conains space partioning functions.
 module partition
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
 
   implicit none
   private
 
   public :: partition_becke, partition_becke_hetero, beckepar
-
 
 contains
 
@@ -31,7 +30,6 @@ contains
     res = 0.5_dp * (1.0_dp - res)
 
   end function partition_becke
-
 
   !> Becke partition function for 2 heteronuclear centers.
   !! \param r1 Distance from 1st center.
@@ -57,7 +55,6 @@ contains
 
   end function partition_becke_hetero
 
-
   !> Delivers parameter aij in the becke partition scheme for given atomic
   !! radii.
   !! \param r1 Radius of the first atom.
@@ -77,5 +74,5 @@ contains
     end if
 
   end function beckepar
-    
+
 end module partition

--- a/sktwocnt/lib/quadrature.f90
+++ b/sktwocnt/lib/quadrature.f90
@@ -1,6 +1,6 @@
 module quadratures
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use common_constants
 
   implicit none
@@ -25,8 +25,8 @@ contains
     integer :: mm, ii, jj
     real(dp) :: zz, z1, pp, p1, p2, p3, rj
 
-    allocate(quad%xx(nn))
-    allocate(quad%ww(nn))
+    allocate(quad % xx(nn))
+    allocate(quad % ww(nn))
     mm = (nn + 1) / 2
     do ii = 1, mm
       zz = cos(pi * (real(ii, dp) - 0.25_dp) / (real(nn, dp) + 0.5_dp))
@@ -46,20 +46,19 @@ contains
           exit
         end if
       end do
-      quad%xx(ii) = -zz
-      quad%xx(nn + 1 - ii) = zz
-      quad%ww(ii) = 2.0_dp / ((1.0_dp - zz * zz) * pp * pp)
-      quad%ww(nn + 1 - ii) = quad%ww(ii)
+      quad % xx(ii) = -zz
+      quad % xx(nn + 1 - ii) = zz
+      quad % ww(ii) = 2.0_dp / ((1.0_dp - zz * zz) * pp * pp)
+      quad % ww(nn + 1 - ii) = quad % ww(ii)
     end do
-    
-  end subroutine gauss_legendre_quadrature
 
+  end subroutine gauss_legendre_quadrature
 
   !> Gauss-Chebishev quadrature for integration in the interval [-1,1].
   !!
   !! Integration of functions with Gauss-Chebishev quadrature of second kind.
   !! The weights already contain 1/sqrt(1-x^2) so that it can be directly
-  !! used to integrate a function on [-1,1]. 
+  !! used to integrate a function on [-1,1].
   !! See also: J. M. Pérez-Jordá et al., J. Chem. Phys. 100 6520 (1994).
   !!
   !! \param nn Number of points for the quadrature
@@ -71,21 +70,20 @@ contains
     integer :: ii
     real(dp) :: rtmp
 
-    allocate(quad%xx(nn))
-    allocate(quad%ww(nn))
+    allocate(quad % xx(nn))
+    allocate(quad % ww(nn))
     !do ii = 1, nn
     !  quad%xx(ii) = cos(pi * (real(ii, dp) - 0.5_dp) / real(nn, dp))
     !end do
     !quad%ww = pi / real(nn, dp)
     do ii = 1, nn
       rtmp = real(ii, dp) * pi / real(nn + 1, dp)
-      quad%xx(ii) = cos(rtmp)
-      quad%ww(ii) = sin(rtmp)
+      quad % xx(ii) = cos(rtmp)
+      quad % ww(ii) = sin(rtmp)
     end do
-    quad%ww = quad%ww * pi / real(nn + 1, dp)
-    
-  end subroutine gauss_chebyshev_quadrature
+    quad % ww = quad % ww * pi / real(nn + 1, dp)
 
+  end subroutine gauss_chebyshev_quadrature
 
   !> Trapezoidal quadrature for integration in the interval [-1,1].
   !! \param nn Number of points for the quadrature
@@ -98,15 +96,14 @@ contains
     integer :: ii
     real(dp) :: fac
 
-    allocate(quad%xx(nn))
-    allocate(quad%ww(nn))
+    allocate(quad % xx(nn))
+    allocate(quad % ww(nn))
     fac = 2.0_dp / real(nn, dp)
     do ii = 1, nn
-      quad%xx(ii) = -1.0_dp + fac * real(ii - 1, dp)
+      quad % xx(ii) = -1.0_dp + fac * real(ii - 1, dp)
     end do
-    quad%ww = fac
+    quad % ww = fac
 
   end subroutine trapezoidal_quadrature
-
 
 end module quadratures

--- a/sktwocnt/lib/sphericalharmonics.f90
+++ b/sktwocnt/lib/sphericalharmonics.f90
@@ -1,7 +1,7 @@
 !> Spherical harmonics.
 module sphericalharmonics
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
 
   implicit none
   private
@@ -40,11 +40,10 @@ contains
     type(realtess), intent(inout) :: self
     integer, intent(in) :: ll, mm
 
-    self%ll = ll
-    self%mm = mm
-    
-  end subroutine realtess_init
+    self % ll = ll
+    self % mm = mm
 
+  end subroutine realtess_init
 
   !> Destroys the instance.
   !! \param self instance.
@@ -52,10 +51,9 @@ contains
     type(realtess), intent(inout) :: self
 
     continue
-    
+
   end subroutine realtess_destruct
 
-   
   !> returns the value of the tessereal function.
   !! \param self instance.
   !! \param theta spherical coordinate theta.
@@ -65,22 +63,18 @@ contains
     real(dp), intent(in) :: theta, phi
     real(dp) :: ang
 
-    ang = calc_realtess(self%ll, self%mm, theta, phi)
-    
-  end function realtess_getvalue
+    ang = calc_realtess(self % ll, self % mm, theta, phi)
 
+  end function realtess_getvalue
 
   elemental function realtess_getvalue_1d(self, theta) result(ang)
     type(realtess), intent(in) :: self
     real(dp), intent(in) :: theta
     real(dp) :: ang
 
-    ang = calc_realtess_1d(self%ll, self%mm, theta)
-    
-  end function realtess_getvalue_1d
-  
-  
+    ang = calc_realtess_1d(self % ll, self % mm, theta)
 
+  end function realtess_getvalue_1d
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! private functions
@@ -92,66 +86,65 @@ contains
   !! \param theta spherical coordinate theta.
   !! \param phi spherical coordinate phi.
   !! \return value of the real tesseral harmonics.
-  elemental function calc_realtess(ll, mm, theta, phi) result (rty)
+  elemental function calc_realtess(ll, mm, theta, phi) result(rty)
     integer, intent(in) :: ll
     integer, intent(in) :: mm
     real(dp), intent(in) :: theta, phi
     real(dp) :: rty
-    
+
     !assert(ll >= 0 .and. ll <= 3)
     !assert(abs(mm) <= ll)
-    
+
     select case (ll)
-    case(0)
+    case (0)
       rty = 0.2820947917738782_dp
-    case(1)
-      select case(mm)
-      case(-1)
+    case (1)
+      select case (mm)
+      case (-1)
         rty = 0.4886025119029198_dp * sin(theta) * sin(phi)
-      case(0)
+      case (0)
         rty = 0.4886025119029198_dp * cos(theta)
-      case(1)
+      case (1)
         rty = 0.4886025119029198_dp * sin(theta) * cos(phi)
       end select
-    case(2)
-      select case(mm)
-      case(-2)
+    case (2)
+      select case (mm)
+      case (-2)
         rty = 0.5462742152960395_dp * sin(theta)**2 * sin(2.0_dp * phi)
-      case(-1)
+      case (-1)
         rty = 1.092548430592079_dp * sin(theta) * cos(theta) * sin(phi)
-      case(0)
+      case (0)
         rty = 0.9461746957575600_dp * cos(theta)**2 - 0.3153915652525200_dp
-      case(1)
+      case (1)
         rty = 1.092548430592079_dp * sin(theta) * cos(theta) * cos(phi)
-      case(2)
+      case (2)
         rty = 0.5462742152960395_dp * sin(theta)**2 * cos(2.0_dp * phi)
       end select
-    case(3)
+    case (3)
       select case (mm)
-      case(-3)
+      case (-3)
         rty = 0.5900435899266435_dp * sin(theta)**3 * sin(3.0_dp * phi)
-      case(-2)
+      case (-2)
         rty = 1.445305721320277_dp * sin(theta)**2 * cos(theta) &
-            &* sin(2.0_dp * phi)
-      case(-1)
+             &* sin(2.0_dp * phi)
+      case (-1)
         rty = 0.4570457994644658_dp * sin(theta) &
-            &* (5.0_dp * cos(theta)**2 - 1.0_dp) * sin(phi)
-      case(0)
+             &* (5.0_dp * cos(theta)**2 - 1.0_dp) * sin(phi)
+      case (0)
         rty = 0.3731763325901155_dp * cos(theta) &
-            &* (5.0_dp * cos(theta)**2 - 3.0_dp)
-      case(1)
+             &* (5.0_dp * cos(theta)**2 - 3.0_dp)
+      case (1)
         rty = 0.4570457994644658_dp * sin(theta) &
-            &* (5.0_dp * cos(theta)**2 - 1.0_dp) * cos(phi)
-      case(2)
+             &* (5.0_dp * cos(theta)**2 - 1.0_dp) * cos(phi)
+      case (2)
         rty = 1.445305721320277_dp * sin(theta)**2 * cos(theta) &
-            &* cos(2.0_dp * phi)
-      case(3)
+             &* cos(2.0_dp * phi)
+      case (3)
         rty = 0.5900435899266435_dp * sin(theta)**3 * cos(3.0_dp * phi)
       end select
     end select
-    
-  end function calc_realtess
 
+  end function calc_realtess
 
   !> Real tessereal spherical harmonics up to f.
   !! \param ll angular momentum (l).
@@ -159,62 +152,62 @@ contains
   !! \param theta spherical coordinate theta.
   !! \param phi spherical coordinate phi.
   !! \return value of the real tesseral harmonics.
-  elemental function calc_realtess_1d(ll, mm, theta) result (rty)
+  elemental function calc_realtess_1d(ll, mm, theta) result(rty)
     integer, intent(in) :: ll
     integer, intent(in) :: mm
     real(dp), intent(in) :: theta
     real(dp) :: rty
-    
+
     !assert(ll >= 0 .and. ll <= 3)
     !assert(abs(mm) <= ll)
-    
+
     select case (ll)
-    case(0)
+    case (0)
       rty = 0.2820947917738782_dp
-    case(1)
-      select case(mm)
-      case(-1)
-        rty = 0.4886025119029198_dp * sin(theta)
-      case(0)
-        rty = 0.4886025119029198_dp * cos(theta)
-      case(1)
-        rty = 0.4886025119029198_dp * sin(theta)
-      end select
-    case(2)
-      select case(mm)
-      case(-2)
-        rty = 0.5462742152960395_dp * sin(theta)**2
-      case(-1)
-        rty = 1.092548430592079_dp * sin(theta) * cos(theta)
-      case(0)
-        rty = 0.9461746957575600_dp * cos(theta)**2 - 0.3153915652525200_dp
-      case(1)
-        rty = 1.092548430592079_dp * sin(theta) * cos(theta)
-      case(2)
-        rty = 0.5462742152960395_dp * sin(theta)**2
-      end select
-    case(3)
+    case (1)
       select case (mm)
-      case(-3)
+      case (-1)
+        rty = 0.4886025119029198_dp * sin(theta)
+      case (0)
+        rty = 0.4886025119029198_dp * cos(theta)
+      case (1)
+        rty = 0.4886025119029198_dp * sin(theta)
+      end select
+    case (2)
+      select case (mm)
+      case (-2)
+        rty = 0.5462742152960395_dp * sin(theta)**2
+      case (-1)
+        rty = 1.092548430592079_dp * sin(theta) * cos(theta)
+      case (0)
+        rty = 0.9461746957575600_dp * cos(theta)**2 - 0.3153915652525200_dp
+      case (1)
+        rty = 1.092548430592079_dp * sin(theta) * cos(theta)
+      case (2)
+        rty = 0.5462742152960395_dp * sin(theta)**2
+      end select
+    case (3)
+      select case (mm)
+      case (-3)
         rty = 0.5900435899266435_dp * sin(theta)**3
-      case(-2)
+      case (-2)
         rty = 1.445305721320277_dp * sin(theta)**2 * cos(theta)
-      case(-1)
+      case (-1)
         rty = 0.4570457994644658_dp * sin(theta) &
-            &* (5.0_dp * cos(theta)**2 - 1.0_dp)
-      case(0)
+             &* (5.0_dp * cos(theta)**2 - 1.0_dp)
+      case (0)
         rty = 0.3731763325901155_dp * cos(theta) &
-            &* (5.0_dp * cos(theta)**2 - 3.0_dp)
-      case(1)
+             &* (5.0_dp * cos(theta)**2 - 3.0_dp)
+      case (1)
         rty = 0.4570457994644658_dp * sin(theta) &
-            &* (5.0_dp * cos(theta)**2 - 1.0_dp)
-      case(2)
+             &* (5.0_dp * cos(theta)**2 - 1.0_dp)
+      case (2)
         rty = 1.445305721320277_dp * sin(theta)**2 * cos(theta)
-      case(3)
+      case (3)
         rty = 0.5900435899266435_dp * sin(theta)**3
       end select
     end select
-    
+
   end function calc_realtess_1d
 
 end module sphericalharmonics

--- a/sktwocnt/lib/twocnt.f90
+++ b/sktwocnt/lib/twocnt.f90
@@ -2,7 +2,7 @@
 module twocnt
 
   use omp_lib
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use common_constants
   use quadratures
   use coordtrans
@@ -23,7 +23,7 @@ module twocnt
   type atomdata
     integer :: nbasis
     integer, allocatable :: angmoms(:)
-    type(gridorb2), allocatable  :: rad(:), drad(:), ddrad(:)
+    type(gridorb2), allocatable :: rad(:), drad(:), ddrad(:)
     type(gridorb2) :: pot, rho, drho, ddrho
   end type atomdata
 
@@ -37,121 +37,118 @@ module twocnt
     type(atomdata) :: atom1, atom2
   end type twocnt_in
 
-
   !> Type for mapping integrals.
   type integmap
     !> Nr. of all nonzero twocenter integrals between orbitals of two atoms.
     integer :: ninteg
 
     !> Indicates for every integral the integrands:
-    !! 
+    !!
     !! o type(1,ii): index of orbital on first atom for integral ii.
     !! o type(2,ii): index of orbital on second atom for integral ii
     !! o type(3,ii): interaction type for integral ii: (0 - sigma, 1 - pi, ...)
-    integer, allocatable :: type(:,:)
+    integer, allocatable :: type(:, :)
 
     !> Indicates which integral corresponds to a given (i1, i2, mm) combination,
     !! where i1 and i2 are the orbital indices on the two atoms and mm the
     !! interaction type. If the integral vanishes, the corresponding elemet is 0.
-    integer, allocatable :: index(:,:,:)
+    integer, allocatable :: index(:, :, :)
   contains
     procedure :: init => integmap_init
   end type integmap
 
-  
 contains
 
   subroutine get_twocenter_integrals(inp, imap, skham, skover)
     type(twocnt_in), target, intent(in) :: inp
     type(integmap), intent(out) :: imap
-    real(dp), allocatable, intent(out) :: skham(:,:), skover(:,:)
+    real(dp), allocatable, intent(out) :: skham(:, :), skover(:, :)
 
     type(quadrature) :: quads(2)
 
     type(atomdata), pointer :: atom1, atom2
     type(TFiFoReal2) :: hamfifo, overfifo
-    real(dp), allocatable :: grid1(:,:), grid2(:,:)
+    real(dp), allocatable :: grid1(:, :), grid2(:, :)
     real(dp), allocatable :: dots(:), weights(:)
     real(dp), allocatable :: denserr(:)
-    real(dp), allocatable :: skhambuffer(:,:), skoverbuffer(:,:)
+    real(dp), allocatable :: skhambuffer(:, :), skoverbuffer(:, :)
     real(dp) :: beckepars(1)
     real(dp) :: dist, maxdist, denserrmax, maxabs
     integer :: ir, nbatch, nbatchline
     logical :: converged, dynlen
 
-    call gauss_legendre_quadrature(inp%ninteg1, quads(1))
-    call gauss_legendre_quadrature(inp%ninteg2, quads(2))
+    call gauss_legendre_quadrature(inp % ninteg1, quads(1))
+    call gauss_legendre_quadrature(inp % ninteg2, quads(2))
 
-    atom1 => inp%atom1
-    if (inp%hetero) then
-      atom2 => inp%atom2
+    atom1 => inp % atom1
+    if (inp % hetero) then
+      atom2 => inp % atom2
     else
-      atom2 => inp%atom1
+      atom2 => inp % atom1
     end if
-    call imap%init(atom1, atom2)
+    call imap % init(atom1, atom2)
 
     ! Calculate lines for 1 Bohr in one batch.
     dist = 0.0_dp
-    dynlen = (inp%maxdist > 0.0_dp)
+    dynlen = (inp % maxdist > 0.0_dp)
     if (dynlen) then
-      nbatchline = ceiling(1.0_dp / inp%dr)
-      maxdist = inp%maxdist + real(nbatchline, dp) * inp%dr
+      nbatchline = ceiling(1.0_dp / inp % dr)
+      maxdist = inp % maxdist + real(nbatchline, dp) * inp % dr
     else
-      maxdist = abs(inp%maxdist)
-      nbatchline = ceiling((maxdist - inp%r0) / inp%dr)
+      maxdist = abs(inp % maxdist)
+      nbatchline = ceiling((maxdist - inp % r0) / inp % dr)
     end if
     nbatch = 0
     denserrmax = 0.0_dp
     allocate(denserr(nbatchline))
     do
-      allocate(skhambuffer(imap%ninteg, nbatchline))
-      allocate(skoverbuffer(imap%ninteg, nbatchline))
+      allocate(skhambuffer(imap % ninteg, nbatchline))
+      allocate(skoverbuffer(imap % ninteg, nbatchline))
       write(*, "(A,I0,A,F6.3,A,F6.3)") "Calculating ", nbatchline,&
-          & " lines: r0 = ", inp%r0 + inp%dr * real(nbatch * nbatchline, dp),&
-          & " dr = ", inp%dr
+          & " lines: r0 = ", inp % r0 + inp % dr * real(nbatch * nbatchline, dp),&
+          & " dr = ", inp % dr
       do ir = 1, nbatchline
-        dist = inp%r0 + inp%dr * real(nbatch * nbatchline + ir - 1, dp)
+        dist = inp % r0 + inp % dr * real(nbatch * nbatchline + ir - 1, dp)
         call gengrid2_12(quads, coordtrans_becke_12, partition_becke,&
             & beckepars, dist, grid1, grid2, dots, weights)
         call getskintegrals(atom1, atom2, grid1, grid2, dots, weights,&
-            &inp%density, inp%ixc, imap, skhambuffer(:,ir), skoverbuffer(:,ir),&
+            &inp % density, inp % ixc, imap, skhambuffer(:, ir), skoverbuffer(:, ir),&
             & denserr(ir))
       end do
       denserrmax = max(denserrmax, maxval(denserr))
       maxabs = max(maxval(abs(skhambuffer)), maxval(abs(skoverbuffer)))
       if (dynlen) then
-        converged = (maxabs < inp%epsilon)
+        converged = (maxabs < inp % epsilon)
         ! If new batch gave no contributions above tolerance: omit it and exit
         if (converged .or. dist > maxdist) then
           exit
         end if
         nbatch = nbatch + 1
-        call hamfifo%push_alloc(skhambuffer)
-        call overfifo%push_alloc(skoverbuffer)
+        call hamfifo % push_alloc(skhambuffer)
+        call overfifo % push_alloc(skoverbuffer)
       else
         converged = .true.
-        call hamfifo%push_alloc(skhambuffer)
-        call overfifo%push_alloc(skoverbuffer)
+        call hamfifo % push_alloc(skhambuffer)
+        call overfifo % push_alloc(skoverbuffer)
         exit
       end if
     end do
     if (.not. converged) then
-      write(*, "(A,F6.2,A,ES10.3)") "Warning, maximal distance ", inp%maxdist,&
+      write(*, "(A,F6.2,A,ES10.3)") "Warning, maximal distance ", inp % maxdist,&
           & " reached! Max integral value:", maxabs
     end if
     write(*, "(A,ES10.3)") "Maximal integration error:", denserrmax
 
-    call hamfifo%popall_concat(skham)
-    call overfifo%popall_concat(skover)
+    call hamfifo % popall_concat(skham)
+    call overfifo % popall_concat(skover)
 
   end subroutine get_twocenter_integrals
-
 
   !> Calculate SK-integrals.
   subroutine getskintegrals(atom1, atom2, grid1, grid2, dots, weights,&
       & densitysuper, ixc, imap, skham, skover, denserr)
     type(atomdata), intent(in) :: atom1, atom2
-    real(dp), intent(in), target :: grid1(:,:), grid2(:,:), dots(:), weights(:)
+    real(dp), intent(in), target :: grid1(:, :), grid2(:, :), dots(:), weights(:)
     logical, intent(in) :: densitysuper
     integer, intent(in) :: ixc
     type(integmap), intent(in) :: imap
@@ -159,57 +156,57 @@ contains
 
     type(realtess) :: tes1, tes2
     real(dp), pointer :: r1(:), r2(:), theta1(:), theta2(:)
-    real(dp), allocatable :: radval1(:,:)
-    real(dp), allocatable :: radval2(:,:), radval2p(:,:), radval2pp(:,:)
+    real(dp), allocatable :: radval1(:, :)
+    real(dp), allocatable :: radval2(:, :), radval2p(:, :), radval2pp(:, :)
     real(dp), allocatable :: potval(:), densval(:)
     real(dp), allocatable :: densval1p(:), densval1pp(:)
     real(dp), allocatable :: densval2p(:), densval2pp(:)
     real(dp), allocatable :: spherval1(:), spherval2(:)
     real(dp), allocatable :: absgr(:), laplace(:), gr_grabsgr(:)
-    
+
     real(dp) :: integ1, integ2, dens, prefac
     integer :: ngrid
     integer :: ii, i1, i2, l1, l2, mm
 
-    r1 => grid1(:,1)
-    theta1 => grid1(:,2)
-    r2 => grid2(:,1)
-    theta2 => grid2(:,2)
+    r1 => grid1(:, 1)
+    theta1 => grid1(:, 2)
+    r2 => grid2(:, 1)
+    theta2 => grid2(:, 2)
     ngrid = size(r1)
 
-    allocate(radval1(ngrid, atom1%nbasis))
-    allocate(radval2(ngrid, atom2%nbasis))
-    allocate(radval2p(ngrid, atom2%nbasis))
-    allocate(radval2pp(ngrid, atom2%nbasis))
+    allocate(radval1(ngrid, atom1 % nbasis))
+    allocate(radval2(ngrid, atom2 % nbasis))
+    allocate(radval2p(ngrid, atom2 % nbasis))
+    allocate(radval2pp(ngrid, atom2 % nbasis))
     allocate(spherval1(ngrid))
     allocate(spherval2(ngrid))
     do ii = 1, size(radval1, dim=2)
-      radval1(:,ii) = getvalue(atom1%rad(ii), r1)
+      radval1(:, ii) = getvalue(atom1 % rad(ii), r1)
     end do
     do ii = 1, size(radval2, dim=2)
-      radval2(:,ii) = getvalue(atom2%rad(ii), r2)
-      radval2p(:,ii) = getvalue(atom2%drad(ii), r2)
-      radval2pp(:,ii) = getvalue(atom2%ddrad(ii), r2)
+      radval2(:, ii) = getvalue(atom2 % rad(ii), r2)
+      radval2p(:, ii) = getvalue(atom2 % drad(ii), r2)
+      radval2pp(:, ii) = getvalue(atom2 % ddrad(ii), r2)
     end do
 
     allocate(potval(ngrid))
     ifPotSup: if (.not. densitysuper) then
-      potval = getvalue(atom1%pot, r1) + getvalue(atom2%pot, r2)
+      potval = getvalue(atom1 % pot, r1) + getvalue(atom2 % pot, r2)
     else
       allocate(densval(ngrid))
-      densval = getvalue(atom1%rho, r1) + getvalue(atom2%rho, r2)
-      select case(ixc)
-      case(1)
+      densval = getvalue(atom1 % rho, r1) + getvalue(atom2 % rho, r2)
+      select case (ixc)
+      case (1)
         call getxcpot_ldapw91(densval, potval)
-      case(2)
+      case (2)
         allocate(densval1p(ngrid))
         allocate(densval1pp(ngrid))
         allocate(densval2p(ngrid))
         allocate(densval2pp(ngrid))
-        densval1p = getvalue(atom1%drho, r1)
-        densval1pp = getvalue(atom1%ddrho, r1)
-        densval2p = getvalue(atom2%drho, r2)
-        densval2pp = getvalue(atom2%ddrho, r2)
+        densval1p = getvalue(atom1 % drho, r1)
+        densval1pp = getvalue(atom1 % ddrho, r1)
+        densval2p = getvalue(atom2 % drho, r2)
+        densval2pp = getvalue(atom2 % ddrho, r2)
         allocate(absgr(ngrid))
         allocate(laplace(ngrid))
         allocate(gr_grabsgr(ngrid))
@@ -223,26 +220,26 @@ contains
         stop
       end select
       ! Add nuclear and coulomb potential
-      potval = potval + getvalue(atom1%pot, r1) + getvalue(atom2%pot, r2)
+      potval = potval + getvalue(atom1 % pot, r1) + getvalue(atom2 % pot, r2)
     end if ifPotSup
 
     denserr = 0.0_dp
-    do ii = 1, imap%ninteg
-      i1 = imap%type(1, ii)
-      l1 = atom1%angmoms(i1)
-      i2 = imap%type(2, ii)
-      l2 = atom2%angmoms(i2)
-      mm = imap%type(3, ii) - 1
+    do ii = 1, imap % ninteg
+      i1 = imap % type(1, ii)
+      l1 = atom1 % angmoms(i1)
+      i2 = imap % type(2, ii)
+      l2 = atom2 % angmoms(i2)
+      mm = imap % type(3, ii) - 1
       call init(tes1, l1, mm)
       call init(tes2, l2, mm)
       spherval1 = getvalue_1d(tes1, theta1)
       spherval2 = getvalue_1d(tes2, theta2)
-      integ1 = gethamiltonian(radval1(:,i1), radval2(:,i2), &
-          &radval2p(:,i2), radval2pp(:,i2), r2, l2, spherval1, &
+      integ1 = gethamiltonian(radval1(:, i1), radval2(:, i2), &
+          &radval2p(:, i2), radval2pp(:, i2), r2, l2, spherval1, &
           &spherval2, potval, weights)
-      integ2 = getoverlap(radval1(:,i1), radval2(:,i2), spherval1, &
+      integ2 = getoverlap(radval1(:, i1), radval2(:, i2), spherval1, &
           &spherval2, weights)
-      dens = getdensity(radval1(:,i1), radval2(:,i2), spherval1, &
+      dens = getdensity(radval1(:, i1), radval2(:, i2), spherval1, &
           &spherval2, weights)
       if (mm == 0) then
         prefac = 2.0_dp * pi
@@ -257,28 +254,21 @@ contains
 
   end subroutine getskintegrals
 
-
-
-
-
-
   function getoverlap(rad1, rad2, spher1, spher2, weights) result(res)
     real(dp), intent(in) :: rad1(:), rad2(:), spher1(:), spher2(:), weights(:)
     real(dp) :: res
 
     res = sum(rad1 * rad2 * spher1 * spher2 * weights)
-    
-  end function getoverlap
 
+  end function getoverlap
 
   function getdensity(rad1, rad2, spher1, spher2, weights) result(res)
     real(dp), intent(in) :: rad1(:), rad2(:), spher1(:), spher2(:), weights(:)
     real(dp) :: res
 
     res = sum(((rad1 * spher1)**2 + (rad2 * spher2)**2) * weights)
-    
-  end function getdensity
 
+  end function getdensity
 
   function gethamiltonian(rad1, rad2, rad2p, rad2pp, r2, l2, spher1, spher2, &
       &pot, weights) result(res)
@@ -286,17 +276,15 @@ contains
     integer, intent(in) :: l2
     real(dp), intent(in) :: spher1(:), spher2(:), pot(:), weights(:)
     real(dp) :: res
-    
+
     res = sum((rad1 * spher1) &
         &* (-0.5_dp * rad2pp &
         &- rad2p / r2 &
         &+ 0.5_dp * l2 * (l2 + 1) * rad2 / r2**2&
         &+ pot * rad2) &
         &* spher2 * weights)
-    
+
   end function gethamiltonian
-
-
 
   subroutine getderivs(drho1, d2rho1, drho2, d2rho2, r1, r2, dots, &
       &absgr, laplace, gr_grabsgr)
@@ -314,16 +302,15 @@ contains
     absgr = sqrt(drho1 * f1 + drho2 * f2)
     laplace = d2rho1 + d2rho2 + 2.0_dp * (drho1 / r1 + drho2 / r2)
     where (absgr > epsilon(1.0_dp))
-      gr_grabsgr = (d2rho1 * f1 * f1 +  d2rho2 * f2 * f2 &
-          &+(1.0_dp - dots**2) * drho1 * drho2 * (drho2 / r1 + drho1 / r2)) &
+      gr_grabsgr = (d2rho1 * f1 * f1 + d2rho2 * f2 * f2 &
+          &+ (1.0_dp - dots**2) * drho1 * drho2 * (drho2 / r1 + drho1 / r2)) &
           &/ absgr
     elsewhere
       gr_grabsgr = 0.0_dp
     end where
-        
+
   end subroutine getderivs
 
-  
   !> Initializes the twocenter integration map based on the basis on two atoms.
   !! \param self  Instance.
   !! \param atom1  Properties of atom1.
@@ -333,38 +320,37 @@ contains
     type(atomdata), intent(in) :: atom1, atom2
 
     integer :: mmax, ninteg, ind, i1, l1, i2, l2, mm
-  
-    mmax = min(maxval(atom1%angmoms), maxval(atom2%angmoms))
-    allocate(self%index(atom1%nbasis, atom2%nbasis, mmax+1))
-    self%index = 0
+
+    mmax = min(maxval(atom1 % angmoms), maxval(atom2 % angmoms))
+    allocate(self % index(atom1 % nbasis, atom2 % nbasis, mmax + 1))
+    self % index = 0
     ninteg = 0
-    do i1 = 1, atom1%nbasis
-      l1 = atom1%angmoms(i1)
-      do i2 = 1, atom2%nbasis
-        l2 = atom2%angmoms(i2)
+    do i1 = 1, atom1 % nbasis
+      l1 = atom1 % angmoms(i1)
+      do i2 = 1, atom2 % nbasis
+        l2 = atom2 % angmoms(i2)
         do mm = 0, min(l1, l2)
-          print *, l1, l2, mm
+          print*,l1, l2, mm
           ninteg = ninteg + 1
-          self%index(i1, i2, mm+1) = ninteg
+          self % index(i1, i2, mm + 1) = ninteg
         end do
       end do
     end do
-    self%ninteg = ninteg
-    allocate(self%type(3, ninteg))
+    self % ninteg = ninteg
+    allocate(self % type(3, ninteg))
     ind = 0
-    do i1 = 1, atom1%nbasis
-      l1 = atom1%angmoms(i1)
-      do i2 = 1, atom2%nbasis
-        l2 = atom2%angmoms(i2)
+    do i1 = 1, atom1 % nbasis
+      l1 = atom1 % angmoms(i1)
+      do i2 = 1, atom2 % nbasis
+        l2 = atom2 % angmoms(i2)
         do mm = 1, min(l1, l2) + 1
           ind = ind + 1
-          self%type(:, ind) = [ i1, i2, mm ]
+          self % type(:, ind) = [i1, i2, mm]
         end do
       end do
     end do
 
   end subroutine integmap_init
 
-
 end module twocnt
-    
+

--- a/sktwocnt/prog/cmdargs.f90
+++ b/sktwocnt/prog/cmdargs.f90
@@ -4,14 +4,13 @@ module cmdargs
   character(*), parameter :: programName = 'sktwocnt'
   character(*), parameter :: programVersion = '0.9'
 
-
 contains
 
   subroutine parse_command_arguments()
-    
+
     integer :: nArgs, argLen
     character(:), allocatable :: arg
-    
+
     nArgs = command_argument_count()
     if (nArgs > 0) then
       call get_command_argument(1, length=argLen)
@@ -28,5 +27,5 @@ contains
     end if
 
   end subroutine parse_command_arguments
-  
+
 end module cmdargs

--- a/sktwocnt/prog/input.f90
+++ b/sktwocnt/prog/input.f90
@@ -1,6 +1,6 @@
 module input
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use gridorbital
   use twocnt, only: twocnt_in, atomdata
   implicit none
@@ -25,60 +25,58 @@ contains
     logical :: readradderivs
 
     fp = 14
-    open(fp, file=inputfile, form="formatted", action="read")
+    open (fp, file=inputfile, form="formatted", action="read")
     !! General part
     iline = 0
     call nextline_(fp, iline, line)
-    read(line, *, iostat=iostat) buffer1, buffer2
+    read (line, *, iostat=iostat) buffer1, buffer2
     call checkerror_(inputfile, line, iline, iostat)
     if (buffer1 /= "hetero" .and. buffer1 /= "homo") then
       call error_("Wrong interaction (must be hetero or homo)", inputfile, &
           &line, iline)
     end if
-    inp%hetero = (buffer1 == "hetero")
+    inp % hetero = (buffer1 == "hetero")
     select case (buffer2)
-    case("potential")
-      inp%density = .false.
-      inp%ixc = 0
-    case("density_lda")
-      inp%density = .true.
-      inp%ixc = 1
-    case("density_pbe")
-      inp%density = .true.
-      inp%ixc = 2
+    case ("potential")
+      inp % density = .false.
+      inp % ixc = 0
+    case ("density_lda")
+      inp % density = .true.
+      inp % ixc = 1
+    case ("density_pbe")
+      inp % density = .true.
+      inp % ixc = 2
     case default
       call error_("Wrong superposition mode (must be potential, density_lda &
           &or density_pbe", inputfile, line, iline)
     end select
-    
+
     call nextline_(fp, iline, line)
-    read(line, *, iostat=iostat) inp%r0, inp%dr, inp%epsilon, inp%maxdist
+    read (line, *, iostat=iostat) inp % r0, inp % dr, inp % epsilon, inp % maxdist
     call checkerror_(inputfile, line, iline, iostat)
 
     call nextline_(fp, iline, line)
-    read(line, *, iostat=iostat) inp%ninteg1, inp%ninteg2
+    read (line, *, iostat=iostat) inp % ninteg1, inp % ninteg2
     call checkerror_(inputfile, line, iline, iostat)
 
-    if (inp%density) then
+    if (inp % density) then
       allocate(potcomps(2))
-      potcomps = [ 2, 3 ]
+      potcomps = [2, 3]
     else
       allocate(potcomps(3))
-      potcomps = [ 2, 3, 4 ]
+      potcomps = [2, 3, 4]
     end if
-    readradderivs = .not. inp%hetero
-    call readatom_(inputfile, fp, iline, potcomps, inp%density, readradderivs, &
-        &inp%atom1)
-    if (inp%hetero) then
-      call readatom_(inputfile, fp, iline, potcomps, inp%density, .true., &
-          &inp%atom2)
+    readradderivs = .not. inp % hetero
+    call readatom_(inputfile, fp, iline, potcomps, inp % density, readradderivs, &
+        &inp % atom1)
+    if (inp % hetero) then
+      call readatom_(inputfile, fp, iline, potcomps, inp % density, .true., &
+          &inp % atom2)
     end if
-    
-    close(fp)
-    
+
+    close (fp)
+
   end subroutine readinput
-
-
 
   subroutine readatom_(fname, fp, iline, potcomps, density, radderivs, atom)
     character(*), intent(in) :: fname
@@ -89,81 +87,78 @@ contains
     type(atomdata), intent(out) :: atom
 
     character(maxlen) :: line, buffer
-    real(dp), allocatable :: data(:,:), potval(:)
-    real(dp) :: vals(1)
+    real(dp), allocatable :: data(:, :), potval(:)
     integer :: ii, iostat, imax
 
-
     call nextline_(fp, iline, line)
-    read(line, *, iostat=iostat) atom%nbasis
+    read (line, *, iostat=iostat) atom % nbasis
     call checkerror_(fname, line, iline, iostat)
-    
-    allocate(atom%angmoms(atom%nbasis))
-    allocate(atom%rad(atom%nbasis))
+
+    allocate(atom % angmoms(atom % nbasis))
+    allocate(atom % rad(atom % nbasis))
     if (radderivs) then
-      allocate(atom%drad(atom%nbasis))
-      allocate(atom%ddrad(atom%nbasis))
+      allocate(atom % drad(atom % nbasis))
+      allocate(atom % ddrad(atom % nbasis))
     end if
-    do ii = 1, atom%nbasis
+    do ii = 1, atom % nbasis
       call nextline_(fp, iline, line)
-      read(line, *, iostat=iostat) buffer, atom%angmoms(ii)
+      read (line, *, iostat=iostat) buffer, atom % angmoms(ii)
       call checkerror_(fname, line, iline, iostat)
       if (radderivs) then
-        call readdata_(buffer, [ 1, 3, 4, 5 ], data)
-        call init(atom%rad(ii), data(:,1), data(:,2))
-        call init(atom%drad(ii), data(:,1), data(:,3))
-        call init(atom%ddrad(ii), data(:,1), data(:,4))
+        call readdata_(buffer, [1, 3, 4, 5], data)
+        call init(atom % rad(ii), data(:, 1), data(:, 2))
+        call init(atom % drad(ii), data(:, 1), data(:, 3))
+        call init(atom % ddrad(ii), data(:, 1), data(:, 4))
       else
-        call readdata_(buffer, [ 1, 3 ], data)
-        call init(atom%rad(ii), data(:,1), data(:,2))
+        call readdata_(buffer, [1, 3], data)
+        call init(atom % rad(ii), data(:, 1), data(:, 2))
       end if
       ! Check if wave function follows the sign convention
       ! (positive where abs(r * R(r)) has its maximum)
-      imax = maxloc(abs(data(:,1) * data(:,2)), dim=1)
-      if (data(imax,2) < 0.0_dp) then
-          write(*, "(A,F5.2,A)") "Wave function negative at the maximum of&
-              & radial probability (r =", data(imax,1), " Bohr)"
-          write(*, "(A)") "Please change the sign of the wave function (and of&
-              & its derivatives)!"
-          write(*, "(A,A,A)") "File: '", trim(buffer), "'"
-          stop
-        end if
+      imax = maxloc(abs(data(:, 1) * data(:, 2)), dim=1)
+      if (data(imax, 2) < 0.0_dp) then
+        write(*, "(A,F5.2,A)") "Wave function negative at the maximum of&
+            & radial probability (r =", data(imax, 1), " Bohr)"
+        write(*, "(A)") "Please change the sign of the wave function (and of&
+            & its derivatives)!"
+        write(*, "(A,A,A)") "File: '", trim(buffer), "'"
+        stop
+      end if
     end do
-    call checkangmoms_(atom%angmoms)
+    call checkangmoms_(atom % angmoms)
 
     call nextline_(fp, iline, line)
     read(line, *, iostat=iostat) buffer
     call checkerror_(fname, line, iline, iostat)
-    call readdata_(buffer, [ 1, 3, 4, 5 ], data)
+    call readdata_(buffer, [1, 3, 4, 5], data)
     allocate(potval(size(data, dim=1)))
     potval = 0.0_dp
     do ii = 1, size(potcomps)
-      potval = potval + data(:,potcomps(ii))
+      potval = potval + data(:, potcomps(ii))
     end do
-    call init(atom%pot, data(:,1), potval)
-    
+    call init(atom % pot, data(:, 1), potval)
+
     call nextline_(fp, iline, line)
     read(line, *, iostat=iostat) buffer
     call checkerror_(fname, line, iline, iostat)
     if (density) then
-      call readdata_(buffer, [ 1, 3, 4, 5 ], data)
-      call init(atom%rho, data(:,1), data(:,2))
-      call init(atom%drho, data(:,1), data(:,3))
-      call init(atom%ddrho, data(:,1), data(:,4))
+      call readdata_(buffer, [1, 3, 4, 5], data)
+      call init(atom % rho, data(:, 1), data(:, 2))
+      call init(atom % drho, data(:, 1), data(:, 3))
+      call init(atom % ddrho, data(:, 1), data(:, 4))
     else
       if (trim(line) /= "noread") then
-        write(*,"(A,I0,A)") "Line ", iline, &
+        write(*, "(A,I0,A)") "Line ", iline, &
             &" ignored since density is not needed."
       end if
     end if
 
   end subroutine readatom_
-  
-  
+
   subroutine readdata_(fname, cols, data)
     character(*), intent(in) :: fname
     integer, intent(in) :: cols(:)
-    real(dp), allocatable, intent(out) :: data(:,:)
+    real(dp), allocatable, intent(out) :: data(:, :)
 
     real(dp), allocatable :: tmp(:)
     character(maxlen) :: line
@@ -172,7 +167,7 @@ contains
     fp = 12
     allocate(tmp(maxval(cols)))
     iline = 1
-    open(fp, file=fname, action="read", form="formatted")
+    open (fp, file=fname, action="read", form="formatted")
     call nextline_(fp, iline, line)
     read(line, *, iostat=iostat) ngrid
     call checkerror_(fname, line, iline, iostat)
@@ -181,14 +176,12 @@ contains
       call nextline_(fp, iline, line)
       read(line, *, iostat=iostat) tmp(:)
       call checkerror_(fname, line, iline, iostat)
-      data(ii,:) = tmp(cols)
+      data(ii, :) = tmp(cols)
     end do
-    close(fp)
+    close (fp)
     deallocate(tmp)
-    
-  end subroutine readdata_
 
-  
+  end subroutine readdata_
 
   subroutine nextline_(fp, iline, line)
     integer, intent(in) :: fp
@@ -205,7 +198,7 @@ contains
       if (ii == 0) then
         line = adjustl(buffer)
       else
-        line = adjustl(buffer(1:ii-1))
+        line = adjustl(buffer(1:ii - 1))
       end if
       if (len_trim(line) > 0) then
         exit
@@ -214,12 +207,8 @@ contains
 
   end subroutine nextline_
 
-
-  
   subroutine checkangmoms_(angmoms)
     integer, intent(in) :: angmoms(:)
-
-    integer :: ii
 
     if (maxval(angmoms) > 4) then
       write(*,*) "Only angular momentum up to 'f' is allowed."
@@ -228,7 +217,6 @@ contains
 
   end subroutine checkangmoms_
 
-
   subroutine checkerror_(fname, line, iline, iostat)
     character(*), intent(in) :: fname, line
     integer, intent(in) :: iline, iostat
@@ -236,21 +224,18 @@ contains
     if (iostat /= 0) then
       call error_("Bad syntax", fname, line, iline)
     end if
-    
-  end subroutine checkerror_
 
+  end subroutine checkerror_
 
   subroutine error_(txt, fname, line, iline)
     character(*), intent(in) :: txt, fname, line
     integer, intent(in) :: iline
 
-    write(*,"(A,A)") "!!! Parsing error: ", txt
-    write(*,"(2X,A,A)") "File: ", trim(fname)
-    write(*,"(2X,A,I0)") "Line number: ", iline
-    write(*,"(2X,A,A,A)") "Line: '", trim(line), "'"
+    write(*, "(A,A)") "!!! Parsing error: ", txt
+    write(*, "(2X,A,A)") "File: ", trim(fname)
+    write(*, "(2X,A,I0)") "Line number: ", iline
+    write(*, "(2X,A,A,A)") "Line: '", trim(line), "'"
     stop
   end subroutine error_
-  
-    
-    
+
 end module input

--- a/sktwocnt/prog/main.f90
+++ b/sktwocnt/prog/main.f90
@@ -1,6 +1,6 @@
 program main
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
   use input
   use twocnt
   use output
@@ -9,14 +9,13 @@ program main
 
   type(twocnt_in) :: inp
   type(integmap) :: imap
-  real(dp), allocatable :: skham(:,:), skover(:,:)
+  real(dp), allocatable :: skham(:, :), skover(:, :)
 
-  
   call parse_command_arguments()
   call readinput(inp, "sktwocnt.in")
   write(*, "(A)") "Input done."
   call get_twocenter_integrals(inp, imap, skham, skover)
   write(*, "(A)") "Twocnt done."
   call write_sktables(skham, skover)
-  
+
 end program main

--- a/sktwocnt/prog/output.f90
+++ b/sktwocnt/prog/output.f90
@@ -1,7 +1,7 @@
 !> Output routines for the sktwocnt code.
 module output
 
-  use common_accuracy, only : dp
+  use common_accuracy, only: dp
 
   implicit none
   private
@@ -11,25 +11,23 @@ module output
   ! Maximal angular momentum in the old and the extended old SK file.
   integer, parameter :: LMAX_OLD = 2
   integer, parameter :: LMAX_EXTENDED = 3
-  
 
 contains
 
   subroutine write_sktables(skham, skover)
-    real(dp), intent(in) :: skham(:,:), skover(:,:)
+    real(dp), intent(in) :: skham(:, :), skover(:, :)
 
     call write_sktable_("at1-at2.ham.dat", skham)
     call write_sktable_("at1-at2.over.dat", skover)
 
   end subroutine write_sktables
-  
 
   !> Helper routine writing the SK files.
   !! \param fname  File name.
   !! \param sktable  Slater-Koster type integrals (Hamiltonian or overlap).
   subroutine write_sktable_(fname, sktable)
     character(*), intent(in) :: fname
-    real(dp), intent(in) :: sktable(:,:)
+    real(dp), intent(in) :: sktable(:, :)
 
     integer :: fp, ninteg, nline
     character(11) :: formstr
@@ -39,12 +37,11 @@ contains
     nline = size(sktable, dim=2)
     write(formstr, "(A,I0,A)") "(", ninteg, "ES21.12)"
     fp = 14
-    open(fp, file=fname, status="replace", action="write")
+    open (fp, file=fname, status="replace", action="write")
     write(fp, "(I0)") nline
     write(fp, formstr) sktable
     close(fp)
-    
+
   end subroutine write_sktable_
 
-  
 end module output


### PR DESCRIPTION
This is the very first step to achieve some kind of consistent formatting for sktwocnt. The re-formatting was carried out by the [fprettify](https://github.com/pseewald/fprettify) auto-formatter and is far from perfect. I've had the changes lying around for a while, but since there's now active development going on, I figured we should merge this PR quickly before a ton of conflicts arise. The options that fprettify provides are somewhat limited, I will therefore have to fix some unacceptable formatting (like spaces around derived type '%', ...) in a later PR.

I'v done similar but much more complete work (includes documentation) for the slateratom code. That PR would more or less break every other PR, so I will wait until everything got merged and rebase on main at the given time.