### PR TITLE
Throw error if SCC not converged and max iterations exceeded

### DIFF
--- a/common/lib/CMakeLists.txt
+++ b/common/lib/CMakeLists.txt
@@ -14,6 +14,7 @@ set(sources-f90
   lapack.F90
   lebedev_laikov.F90
   lebedev_laikov_f77.f
+  message.F90
   partition.F90
   poisson.F90
   quadrature.F90

--- a/common/lib/message.F90
+++ b/common/lib/message.F90
@@ -1,0 +1,84 @@
+!> Module that contains routines for throwing messages (warnings/errors) due to runtime events.
+module common_message
+
+  implicit none
+  private
+
+
+  !> Recoverable error warnings.
+  interface warning
+    module procedure warning_single
+    module procedure warning_array
+  end interface
+
+
+  !> Fatal error warnings, terminating the code.
+  interface error
+    module procedure error_single
+    module procedure error_array
+  end interface error
+
+
+  public :: warning, error
+
+
+contains
+
+  !> Throws a single warning message.
+  subroutine warning_single(message)
+
+    !> Warning message to print to standard out
+    character (len=*), intent(in) :: message
+
+    write(*, '(1a)') 'WARNING!'
+    write(*, '(2a)') '-> ', trim(message)
+
+  end subroutine warning_single
+
+
+  !> Throws multiple warning messages.
+  subroutine warning_array(messages)
+
+    !> Lines of the warning message to print to standard out
+    character(len=*), intent(in) :: messages(:)
+
+    integer :: ii
+
+    write(*, '(1a)') 'WARNING!'
+    do ii = 1, size(messages)
+      write(*, '(2a)') '-> ', trim(messages(ii))
+    end do
+
+  end subroutine warning_array
+
+
+  !> Throws a single error message and stops the code.
+  subroutine error_single(message)
+
+    !> Error message to print to standard out
+    character (len=*), intent(in) :: message
+
+    write(*, '(1a)') 'ERROR!'
+    write(*, '(2a)') '-> ', trim(message)
+    error stop
+
+  end subroutine error_single
+
+
+  !> Throws multiple error messages and stops the code.
+  subroutine error_array(messages)
+
+    !> Lines of the error message to print to standard out
+    character(len=*), intent(in) :: messages(:)
+
+    integer :: ii
+
+    write(*, '(1a)') 'ERROR!'
+    do ii = 1, size(messages)
+      write(*, '(2a)') '-> ', trim(messages(ii))
+    end do
+    error stop
+
+  end subroutine error_array
+
+end module common_message

--- a/slateratom/lib/utilities.f90
+++ b/slateratom/lib/utilities.f90
@@ -55,6 +55,8 @@ contains
 
     if (change_max < 1.0e-10_dp) then
       tConverged = .true.
+    else
+      tConverged = .false.
     end if
 
   end subroutine check_convergence

--- a/slateratom/prog/main.f90
+++ b/slateratom/prog/main.f90
@@ -1,6 +1,7 @@
 program HFAtom
 
   use common_accuracy, only : dp
+  use common_message, only : error
   use integration, only : gauss_chebyshev_becke_mesh
   use input, only : read_input_1, read_input_2, echo_input
   use core_overlap, only : overlap, nuclear, kinetic, confinement
@@ -166,6 +167,11 @@ program HFAtom
     write(*,*) ' '
 
   end do lpScf
+
+  ! handle non-converged calculations
+  if (.not. tConverged) then
+    call error('SCC is NOT converged, maximal SCC iterations exceeded.')
+  end if
 
   ! handle output of requested data
 


### PR DESCRIPTION
Slateratom now throws an error message if self-consistency is not reached and the max. number of SCC iterations exceeded. This fixes #29, but it would be nice if the sktools would know what is going on and exit more gracefully.