### PR TITLE
Fix collectwavecoeffs script to extract Waveplot info

### DIFF
--- a/sktools/src/sktools/common.py
+++ b/sktools/src/sktools/common.py
@@ -55,6 +55,10 @@ class SkgenException(Exception):
     '''Custom exception of the skgen script.'''
 
 
+class CollectwavecoeffsException(Exception):
+    '''Custom exception of the collectwavecoeffs script.'''
+
+
 def openfile(fobj, mode):
     '''Opens a file or passes a file object.
 

--- a/sktools/src/sktools/scripts/collectwavecoeffs.py
+++ b/sktools/src/sktools/scripts/collectwavecoeffs.py
@@ -1,31 +1,54 @@
 #!/usr/bin/env python3
 
-'''Collects coefficient information for waveplot.'''
+'''
+Module to extract or calculate wavefunction coefficients for Waveplot.
+'''
 
 
-import os.path
+import os
 
-from sktools.common import ANGMOM_TO_SHELL, writefloats
-from sktools.taggedfile import TaggedFile
-from sktools.skdef import Skdef
+import sktools.common as sc
+from sktools.skgen import compression
+from sktools.scripts.skgen import get_parser_and_subparser_container, \
+    get_onecnt_common_parser, setup_parser_wavecomp, \
+    parse_command_line_and_run_subcommand, \
+    convert_argument_to_elements, merge_skdefs
+from sktools import PACKAGE_VERSION
 from sktools.oldskfile import OldSKFile
+from sktools.taggedfile import TaggedFile
 
 
-USAGE = \
-    '''Collects coefficient information for waveplot. It iterates over the
-    elements defined in skdefs.py and collects the wave function coefficients
-    and other information necessary for waveplot. The homonuclear SK-files for
-    those elements must have been created already. If it is missing, the given
-    element will be ignored.
+SCRIPTNAME = sc.get_script_name()
+
+USAGE = USAGE = \
+    '''Collects coefficient information for Waveplot. It iterates over the
+    elements defined in skdef.hsd and collects the wavefunction coefficients
+    and other information necessary for Waveplot. The homonuclear SK-files as
+    well as atomic calculations with compressed wavefunction must have been
+    generated in advance.
     '''
 
+# Global script logger, will be overriden by the setup_logger() method in
+# the respective subcommands depending on the command line loglevel options
+logger = None
 
-def writecoeffs(fp, elem, atomconfig, homoskname, wavecompdir):
+
+def main(args=None):
+    '''Main driver routine.'''
+
+    parser, subparsers = get_parser_and_subparser_container()
+    setup_parser_main(parser)
+    onecnt_common = get_onecnt_common_parser()
+    setup_parser_wavecomp(subparsers, onecnt_common, run_wavecomp)
+    parse_command_line_and_run_subcommand(parser, args)
+
+
+def writecoeffs(fd_wc, elem, atomconfig, homoskname, wavecompdir):
     '''Writes element-specific input, processed by Waveplot.
 
     Args:
 
-        fp (file object): file object to write to
+        fd_wc (file object): file object to write to
         elem (str): element name to fetch information for
         atomconfig (AtomConfig): represents the configuration of a free atom
         homoskname (str): pathname of homonuclear Slater-Koster file
@@ -35,50 +58,105 @@ def writecoeffs(fp, elem, atomconfig, homoskname, wavecompdir):
 
     homosk = OldSKFile.fromfile(homoskname, True)
     cutoff = homosk.nr * homosk.dr / 2.0
-    fp.write('{} {{\n'.format(elem))
-    fp.write('  AtomicNumber = {:d}\n'.format(atomconfig.znuc))
-    for nn, ll in atomconfig.valenceorbs:
-        coeffsname = 'coeffs_{:02d}{:1s}.tag'.format(nn, ANGMOM_TO_SHELL[ll])
+    fd_wc.write('{} {{\n'.format(elem))
+    fd_wc.write('  AtomicNumber = {:d}\n'.format(int(atomconfig.atomicnumber)))
+    for nn, ll in atomconfig.valenceshells:
+        coeffsname = 'coeffs_{:02d}{:1s}.tag'.format(nn, sc.ANGMOM_TO_SHELL[ll])
         coeffs = TaggedFile.fromfile(os.path.join(wavecompdir, coeffsname),
                                      transpose=True)
-        fp.write('  Orbital {\n')
-        fp.write('    AngularMomentum = {:d}\n'.format(ll))
-        fp.write('    Occupation = {:.1f}\n'.format(coeffs['occupation']))
-        fp.write('    Cutoff = {:5.2f}\n'.format(cutoff))
-        fp.write('    Exponents {\n')
-        writefloats(fp, coeffs['exponents'], indent=6, numperline=3,
-                    formstr='{:21.12E}')
-        fp.write('    }\n')
-        fp.write('    Coefficients {\n')
-        writefloats(fp, coeffs['coefficients'], indent=3, numperline=3,
-                    formstr='{:21.12E}')
-        fp.write('    }\n')
-        fp.write('  }\n')
-    fp.write('}\n')
+        fd_wc.write('  Orbital {\n')
+        fd_wc.write('    AngularMomentum = {:d}\n'.format(ll))
+        fd_wc.write('    Occupation = {:.1f}\n'.format(coeffs['occupation']))
+        fd_wc.write('    Cutoff = {:5.2f}\n'.format(cutoff))
+        fd_wc.write('    Exponents {\n')
+        sc.writefloats(fd_wc, coeffs['exponents'], indent=6, numperline=3,
+                       formstr='{:21.12E}')
+        fd_wc.write('    }\n')
+        fd_wc.write('    Coefficients {\n')
+        sc.writefloats(fd_wc, coeffs['coefficients'], indent=3, numperline=3,
+                       formstr='{:21.12E}')
+        fd_wc.write('    }\n')
+        fd_wc.write('  }\n')
+    fd_wc.write('}\n')
 
 
-def main():
-    '''Main driver routine.'''
+def run_wavecomp(args):
+    setup_logger(args.loglevel)
+    logger.info('Checking if required SK-files are present')
+    elements = convert_argument_to_elements(args.element)
+    elements_lower = [elem.lower() for elem in elements]
 
-    skdefs = Skdef.fromfile('skdefs.py')
-    atomconfigs = skdefs.atomconfigs
-    elems = atomconfigs.keys()
+    for ielem, elem in enumerate(elements_lower):
+        homoskname = '{elem}-{elem}.skf'.format(elem=elem.capitalize())
+        if not os.path.exists(homoskname):
+            sc.fatalerror('Error while processing element ' + elem.capitalize()
+                          + '. SK-file ' + homoskname + ' absent.')
 
-    with open('wfc.hsd', 'w', encoding='utf8') as fp:
+    skdef = merge_skdefs(args.configfiles)
+    searchdirs = [args.builddir,] + args.includedirs
+    resultdirs = []
 
-        for elem in elems:
-            homoskname = '{elem}-{elem}.skf'.format(elem=elem)
-            wavecompdir = os.path.join(elem, 'wavecomp')
-            filespresent = (os.path.exists(homoskname)
-                            and os.path.exists(wavecompdir))
-            if not filespresent:
-                print('*** Skipping: ', elem)
-                continue
+    logger.info('Subcommand wavecomp started')
+    for elem in elements:
+        calculator = compression.search_wavecomp(
+            skdef, elem, args.builddir, searchdirs)
+        dirnames = ' '.join(calculator.get_result_directories())
+        resultdirs.append(dirnames)
 
-            print('*** Processing: ', elem)
-            atomconfig = atomconfigs[elem]
-            writecoeffs(fp, elem, atomconfig, homoskname, wavecompdir)
+    logger.info('Subcommand wavecomp finished')
+    logger.info('Wavecomp results in {}'.format(' '.join(resultdirs)))
+
+    atomparameters = skdef.atomparameters
+
+    with open('wfc.hsd', 'w', encoding='utf8') as fd_wc:
+
+        for ielem, elem in enumerate(elements_lower):
+            homoskname = '{elem}-{elem}.skf'.format(elem=elem.capitalize())
+            wavecompdir = os.path.join(os.getcwd(), resultdirs[ielem])
+            if not os.path.exists(homoskname):
+                sc.fatalerror('Error while processing element '
+                              + elem.capitalize() + '. SK-file ' + homoskname
+                              + ' absent.')
+
+            logger.info('Writing element ' + elem.capitalize()
+                        + ' to wfc.hsd file.')
+            atomconfig = atomparameters[elem].atomconfig
+            writecoeffs(fd_wc, elem.capitalize(), atomconfig, homoskname,
+                        wavecompdir)
+
+
+def setup_parser_main(parser):
+    parser.add_argument('--version', action='version',
+                        version=f'sktools {PACKAGE_VERSION}')
+
+    parser.add_argument(
+        '-I', '--include-dir', action='append', default=[],
+        dest='includedirs',
+        help='directory to include in the search for calculation '
+        '(default: build directory only)')
+
+    parser.add_argument(
+        '-c', '--config-file', action='append', dest='configfiles',
+        default=['skdef.hsd',],
+        help='config file(s) to be parsed (default: skdef.hsd)')
+
+    parser.add_argument(
+        '-b', '--build-dir', default='_build', dest='builddir',
+        help='build directory (default: _build)')
+
+    parser.add_argument(
+        '-l', '--log-level', dest='loglevel', default='info',
+        choices=['debug', 'info', 'warning', 'error'],
+        help='Logging level (default: info)')
+
+
+def setup_logger(loglevel):
+    global logger
+    logger = sc.get_script_logger(loglevel, SCRIPTNAME)
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except sc.CollectwavecoeffsException as ex:
+        sc.fatalerror(str(ex))

--- a/sktools/src/sktools/taggedfile.py
+++ b/sktools/src/sktools/taggedfile.py
@@ -4,7 +4,10 @@ import numpy as np
 
 class TaggedFile(OrderedDict):
 
-    CONVERTER = {"real": float, "integer": int, "logical": lambda x: x.lower() == "t"}
+    CONVERTER = { "real": np.float64,
+                  "integer": np.int64,
+                  "logical": lambda x: x.lower() == "t"
+                  }
 
     DTYPE_NAMES = {
         np.dtype("int64"): "integer",
@@ -17,8 +20,7 @@ class TaggedFile(OrderedDict):
     }
 
     DTYPE_FORMATS = {
-        # Numpy 1.6.1 can't format "int64" as integers in Python 3.2
-        np.dtype("int64"): (3, "{:20d}"),
+        np.dtype("int64"): ( 3, "{:20d}"),
         np.dtype("float64"): (3, "{:23.15E}"),
         np.dtype("bool"): (40, "{:2s}"),
         str: (72, "  {:s}"),


### PR DESCRIPTION
Fixes #36 according to the following concept:

The skgen machinery is used to find out if the required atomic DFT calculations with compressed wavefunction have already been performed in advance. Also, the homonuclear SK-files of the respective elements must be present, since I decided against an on-the-fly calculation in both cases.