### PR TITLE
Remove obsolete copy statement in configuration step

### DIFF
--- a/test/prog/sktable/CMakeLists.txt
+++ b/test/prog/sktable/CMakeLists.txt
@@ -27,11 +27,6 @@ foreach(line IN LISTS sktable_tests_raw)
   endif()
 endforeach()
 
-# copy datasets to build folder
-execute_process(
-  COMMAND ${CMAKE_COMMAND} -E copy_directory
-  ${srcdir}/skdef ${builddir}/skdef)
-
 foreach(test IN LISTS tests)
   add_test(
     NAME sktable_${test}


### PR DESCRIPTION
Originally the idea was to create a database with different skdef.hsd files, but I discarded it. This PR removes an artifact that tries to copy this (no longer existing) folder into the build directory.