### PR TITLE
Improve flexibility of subcommands

### DIFF
--- a/sktools/src/sktools/xcfunctionals.py
+++ b/sktools/src/sktools/xcfunctionals.py
@@ -79,23 +79,15 @@ class XCCAMYB3LYP(sc.ClassDict):
 
         alpha, child = query.getvalue(root, 'alpha', conv.float0,
                                       returnchild=True)
-        if not 0.0 <= alpha <= 1.0:
-            raise hsd.HSDInvalidTagValueException(
-                msg='Invalid alpha CAM-parameter {:f}'.format(alpha),
-                node=child)
 
         beta, child = query.getvalue(root, 'beta', conv.float0,
                                      returnchild=True)
-        if not 0.0 <= beta <= 1.0:
-            raise hsd.HSDInvalidTagValueException(
-                msg='Invalid beta CAM-parameter {:f}'.format(beta),
-                node=child)
 
-        if not 0.0 <= alpha + beta <= 1.0:
+        if not alpha + beta > 0.0:
             raise hsd.HSDInvalidTagValueException(
                 msg='Invalid CAM-parameter combination alpha={:f}, beta={:f}!\n'
                 .format(alpha, beta) +
-                'Should satisfy 0.0 <= alpha + beta <= 1.0', node=child)
+                'Should satisfy alpha + beta > 0.0', node=child)
 
         myself = cls()
         myself.type = 'camy-b3lyp'
@@ -127,23 +119,15 @@ class XCCAMYPBEH(sc.ClassDict):
 
         alpha, child = query.getvalue(root, 'alpha', conv.float0,
                                       returnchild=True)
-        if not 0.0 <= alpha <= 1.0:
-            raise hsd.HSDInvalidTagValueException(
-                msg='Invalid alpha CAM-parameter {:f}'.format(alpha),
-                node=child)
 
         beta, child = query.getvalue(root, 'beta', conv.float0,
                                      returnchild=True)
-        if not 0.0 <= beta <= 1.0:
-            raise hsd.HSDInvalidTagValueException(
-                msg='Invalid beta CAM-parameter {:f}'.format(beta),
-                node=child)
 
-        if not 0.0 <= alpha + beta <= 1.0:
+        if not alpha + beta > 0.0:
             raise hsd.HSDInvalidTagValueException(
                 msg='Invalid CAM-parameter combination alpha={:f}, beta={:f}!\n'
                 .format(alpha, beta) +
-                'Should satisfy 0.0 <= alpha + beta <= 1.0', node=child)
+                'Should satisfy alpha + beta > 0.0', node=child)
 
         myself = cls()
         myself.type = 'camy-pbeh'

--- a/slateratom/lib/globals.f90
+++ b/slateratom/lib/globals.f90
@@ -32,6 +32,9 @@ module globals
   !> maximum number of SCF calculations
   integer :: maxiter
 
+  !> scf tolerance, i.e. convergence criteria
+  real(dp) :: scftol
+
   !> smallest exponent if generate_alpha
   real(dp) :: min_alpha
 

--- a/slateratom/lib/input.f90
+++ b/slateratom/lib/input.f90
@@ -15,10 +15,10 @@ module input
 contains
 
   !> Reads in all properties, except for occupation numbers.
-  subroutine read_input_1(nuc, max_l, occ_shells, maxiter, poly_order, min_alpha, max_alpha,&
-      & num_alpha, tAutoAlphas, alpha, conf_r0, conf_power, num_occ, num_power, num_alphas,&
-      & xcnr, tPrintEigvecs, tZora, tBroyden, mixing_factor, xalpha_const, omega, camAlpha,&
-      & camBeta, grid_params)
+  subroutine read_input_1(nuc, max_l, occ_shells, maxiter, scftol, poly_order, min_alpha,&
+      & max_alpha, num_alpha, tAutoAlphas, alpha, conf_r0, conf_power, num_occ, num_power,&
+      & num_alphas, xcnr, tPrintEigvecs, tZora, tBroyden, mixing_factor, xalpha_const, omega,&
+      & camAlpha, camBeta, grid_params)
 
     !> nuclear charge, i.e. atomic number
     integer, intent(out) :: nuc
@@ -31,6 +31,9 @@ contains
 
     !> maximum number of SCF calculations
     integer, intent(out) :: maxiter
+
+    !> scf tolerance, i.e. convergence criteria
+    real(dp), intent(out) :: scftol
 
     !> highest polynomial order + l in each shell
     integer, intent(out) :: poly_order(0:4)
@@ -98,8 +101,8 @@ contains
     !! auxiliary variables
     integer :: ii, jj
 
-    write(*, '(A)') 'Enter nuclear charge, maximal angular momentum (s=0), max. SCF, ZORA'
-    read(*,*) nuc, max_l, maxiter, tZora
+    write(*, '(A)') 'Enter nuclear charge, maximal angular momentum (s=0), max. SCF, SCF tol., ZORA'
+    read(*,*) nuc, max_l, maxiter, scftol, tZora
 
     write(*, '(A)') 'Enter XC functional:&
         & 0: HF, 1: X-Alpha, 2: LDA-PW91, 3: GGA-PBE96, 4: GGA-BLYP, 5: LCY-PBE96, 6: LCY-BNL,&
@@ -253,8 +256,9 @@ contains
 
 
   !> Echos gathered input to stdout.
-  subroutine echo_input(nuc, max_l, occ_shells, maxiter, poly_order, num_alpha, alpha, conf_r0,&
-      & conf_power, occ, num_occ, num_power, num_alphas, xcnr, tZora, num_mesh_points, xalpha_const)
+  subroutine echo_input(nuc, max_l, occ_shells, maxiter, scftol, poly_order, num_alpha, alpha,&
+      & conf_r0, conf_power, occ, num_occ, num_power, num_alphas, xcnr, tZora, num_mesh_points,&
+      & xalpha_const)
 
     !> nuclear charge, i.e. atomic number
     integer, intent(in) :: nuc
@@ -267,6 +271,9 @@ contains
 
     !> maximum number of SCF calculations
     integer, intent(in) :: maxiter
+
+    !> scf tolerance, i.e. convergence criteria
+    real(dp), intent(in) :: scftol
 
     !> highest polynomial order + l in each shell
     integer, intent(in) :: poly_order(0:)
@@ -335,6 +342,7 @@ contains
     if (xcnr == xcFunctional%CAMY_PBEh) write(*, '(A)') 'CAM: CAMY-PBEh'
 
     write(*, '(A,I6)') 'Max. number of SCF iterations: ', maxiter
+    write(*, '(A,ES9.2E2)') 'SCF tolerance [a.u.]: ', scftol
 
     write(*, '(A,I1)') 'Max. angular momentum: ', max_l
     write(*, '(A,I5)') 'Number of points for numerical radial integration: ', num_mesh_points

--- a/slateratom/lib/utilities.f90
+++ b/slateratom/lib/utilities.f90
@@ -33,7 +33,7 @@ contains
 
 
   !> Checks SCF convergence by comparing new and old potential.
-  pure subroutine check_convergence(pot_old, pot_new, max_l, problemsize, iScf, change_max,&
+  pure subroutine check_convergence(pot_old, pot_new, max_l, problemsize, scftol, iScf, change_max,&
       & tConverged)
 
     !> old and new potential to compare
@@ -44,6 +44,9 @@ contains
 
     !> size of the problem at hand
     integer, intent(in) :: problemsize
+
+    !> scf tolerance, i.e. convergence criteria
+    real(dp), intent(in) :: scftol
 
     !> current SCF step
     integer, intent(in) :: iScf
@@ -73,7 +76,7 @@ contains
       end do
     end do
 
-    if (change_max < 1.0e-10_dp) then
+    if (change_max < scftol) then
       tConverged = .true.
     else
       tConverged = .false.

--- a/slateratom/prog/main.f90
+++ b/slateratom/prog/main.f90
@@ -46,8 +46,8 @@ program HFAtom
   type(TBeckeGridParams) :: grid_params
 
   call parse_command_arguments()
-  call read_input_1(nuc, max_l, occ_shells, maxiter, poly_order, min_alpha, max_alpha, num_alpha,&
-      & tAutoAlphas, alpha, conf_r0, conf_power, num_occ, num_power, num_alphas, xcnr,&
+  call read_input_1(nuc, max_l, occ_shells, maxiter, scftol, poly_order, min_alpha, max_alpha,&
+      & num_alpha, tAutoAlphas, alpha, conf_r0, conf_power, num_occ, num_power, num_alphas, xcnr,&
       & tPrintEigvecs, tZora, tBroyden, mixing_factor, xalpha_const, omega, camAlpha, camBeta,&
       & grid_params)
 
@@ -66,7 +66,7 @@ program HFAtom
   if (nuc > 36) num_mesh_points = 1250
   if (nuc > 54) num_mesh_points = 1500
 
-  call echo_input(nuc, max_l, occ_shells, maxiter, poly_order, num_alpha, alpha, conf_r0,&
+  call echo_input(nuc, max_l, occ_shells, maxiter, scftol, poly_order, num_alpha, alpha, conf_r0,&
       & conf_power, occ, num_occ, num_power, num_alphas, xcnr, tZora, num_mesh_points, xalpha_const)
 
   ! allocate global stuff and zero out
@@ -157,7 +157,8 @@ program HFAtom
           & nuclear_energy, coulomb_energy, exchange_energy, x_en_2, conf_energy, total_ene)
     end if
 
-    call check_convergence(pot_old, pot_new, max_l, problemsize, iScf, change_max, tConverged)
+    call check_convergence(pot_old, pot_new, max_l, problemsize, scftol, iScf, change_max,&
+        & tConverged)
 
     write(*, '(I4,2X,3(1X,F16.9),3X,E16.9)') iScf, total_ene, exchange_energy, x_en_2, change_max
 


### PR DESCRIPTION
Establishes two generalizations:

- [x] allow for negative CAM-alpha and -beta values (necessary for SRSH-functionals)
- [x] make maximum number of SCF steps and SCF convergence tolerance accessible from the user's perspective (skdef.hsd)

```
OnecenterParameters {

  C {
    .
    Calculator = SlaterAtom {
      MaxSCFIterations = 30       # default: 120
      SCFTolerance = 1e-08        # default: 1e-10 a.u.
      .
      .
      }
    }
  }
}
```

Builds upon #40, therefore ideally to be merged afterwards.
Closes #45.
Closes #46.