### PR TITLE
Handle non converged SCF cycles more gracefully

### DIFF
--- a/slateratom/prog/main.f90
+++ b/slateratom/prog/main.f90
@@ -174,7 +174,7 @@ program HFAtom
 
   ! handle non-converged calculations
   if (.not. tConverged) then
-    call error('SCC is NOT converged, maximal SCC iterations exceeded.')
+    call error('SCF is NOT converged, maximal SCF iterations exceeded.')
   end if
 
   ! handle output of requested data


### PR DESCRIPTION
sktools is now issuing a reasonable error message (with basic suggestions how to troubleshoot), if slateratom did not produce required outputs.

Closes #52.