### PR TITLE
Prevent parsing multiple config files

### DIFF
--- a/sktools/src/sktools/scripts/skgen.py
+++ b/sktools/src/sktools/scripts/skgen.py
@@ -168,9 +168,9 @@ def setup_parser_main(parser):
         help='directory to include in the search for calculation '
         '(default: build directory only)')
     parser.add_argument(
-        '-c', '--config-file', action='append', dest='configfiles',
-        default=['skdef.hsd',],
-        help='config file(s) to be parsed (default: ./skdef.hsd)'
+        '-c', '--config-file', default='skdef.hsd', dest='configfiles',
+        metavar='CONFIGFILE',
+        help='config file to be parsed (default: ./skdef.hsd)'
     )
     parser.add_argument(
         '-b', '--build-dir', default='_build', dest='builddir',
@@ -241,6 +241,7 @@ def setup_parser_sktable(subparsers, twocnt_common, target_function):
 
 def parse_command_line_and_run_subcommand(parser, cmdlineargs=None):
     args = parser.parse_args(args=cmdlineargs)
+    args.configfiles = [args.configfiles,]
     args.func(args)
 
 


### PR DESCRIPTION
The update mechanism for parsing multiple configuration files is broken and we should make this (generally useful) feature inaccessible for the time being, at least until the backend has been fixed.

See also https://github.com/dftbplus/skprogs/issues/67#issuecomment-1814766028.