### PR TITLE
Fix bug when parsing occupations

### DIFF
--- a/sktools/src/sktools/calculators/slateratom.py
+++ b/sktools/src/sktools/calculators/slateratom.py
@@ -337,7 +337,7 @@ class SlateratomInput:
                     occ[0], occ[1], self._COMMENT, nn, sc.ANGMOM_TO_SHELL[ll]))
 
         # Occupied shell range
-        occqns = [[sc.MAX_PRINCIPAL_QN, 0],] * (maxang + 1)
+        occqns = [[sc.MAX_PRINCIPAL_QN + 1, 0],] * (maxang + 1)
         for qn, occ in self._atomconfig.occshells:
             nn = qn[0]
             ll = qn[1]

--- a/sktools/src/sktools/skdef.py
+++ b/sktools/src/sktools/skdef.py
@@ -305,7 +305,7 @@ class AtomConfig(sc.ClassDict):
         occnode = query.findchild(root, "occupations")
         for ll, shellname in enumerate(sc.ANGMOM_TO_SHELL):
             occ_l = []
-            for nn in range(ll + 1, sc.MAX_PRINCIPAL_QN):
+            for nn in range(ll + 1, sc.MAX_PRINCIPAL_QN + 1):
                 txt = "{:d}{:s}".format(nn, shellname)
                 shelloccnode = query.findchild(occnode, txt, optional=True)
                 if shelloccnode is None:


### PR DESCRIPTION
While the maximum value for the principle quantum number is set to be $7$, it is not handled correctly as upper bounds are excluded.

Presumably fixes #77.