### PR TITLE
Work around numerical instability of the mio N example

### DIFF
--- a/examples/mio/skdef.hsd
+++ b/examples/mio/skdef.hsd
@@ -314,8 +314,8 @@ OnecenterParameters {
     $StandardDeltaFilling
     Calculator = SlaterAtom {
       Exponents {
-	S = 0.5 1.2 2.9 7.0
-	P = 0.5 1.2 2.9 7.0
+	S = 0.5 1.21 2.9 7.0
+	P = 0.5 1.21 2.9 7.0
       }
       MaxPowers {
 	S = 3


### PR DESCRIPTION
This slight change is enough to work around the numerical instabilities encountered for the nitrogen STO basis of the mio example. In fact, it is even closer to the geometric series `(0.5000 1.2051 2.9044 7.0000)` suggested by `skexp`.

Difference to the original `slateratom` binary (+original exponents), as reported by `skdiff`:
```
*** Atomic data:
Onsite:         2.739e-08     1
Hubbards:       5.742e-07     1
Hubbard (s):    5.742e-07
Occupations:    0.000e+00     0

*** Integral tables:
Hamiltonian:    1.820e-06 ( 104,  9)
Overlap:        4.158e-06 ( 190,  9)
```

Difference to the original `slateratom` binary (+updated exponents), as reported by `skdiff`:
```
*** Atomic data:
Onsite:         8.272e-09     1
Hubbards:       3.631e-07     1
Hubbard (s):    3.631e-07
Occupations:    0.000e+00     0

*** Integral tables:
Hamiltonian:    3.706e-07 (  19,  5)
Overlap:        2.660e-11 (  45,  6)
```

Closes #92 (not really a fix though).