### PR TITLE
add new SCF diagnostic quantities for slateratom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 _gitmsg.saved.txt
 *.egg-info
 dist
+.vscode/

--- a/sktools/src/sktools/calculators/slateratom.py
+++ b/sktools/src/sktools/calculators/slateratom.py
@@ -21,7 +21,7 @@ SUPPORTED_FUNCTIONALS = {'lda' : 2, 'pbe' : 3, 'blyp' : 4, 'lcy-pbe' : 5,
                          'lcy-bnl' : 6, 'pbe0' : 7, 'b3lyp' : 8,
                          'camy-b3lyp' : 9, 'camy-pbeh' : 10}
 
-MIXER_TYPES = {'simple': 1, "broyden": 2, "diis": 3}
+MIXER_TYPES = {'Simple': 1, "Broyden": 2, "DIIS": 3}
 
 INPUT_FILE = "slateratom.in"
 STDOUT_FILE = "output"
@@ -74,6 +74,7 @@ class SlaterAtomSettings(sc.ClassDict):
         self.maxscfiter = maxscfiter
         self.mixer = mixer
         self.mixfactor = mixfactor
+        print(self.__dict__)
 
     @classmethod
     def fromhsd(cls, root, query):
@@ -173,7 +174,7 @@ class SlateratomInput:
             raise sc.SkgenException(msg)
 
         if self._settings.mixer not in MIXER_TYPES:
-            msg = "SlaterAtom: unsupported mixer (must be either simple, Broyden, or DIIS)"
+            msg = "SlaterAtom: unsupported mixer (must be either Simple, Broyden, or DIIS)"
             raise sc.SkgenException(msg)
 
         if not (0. <= self._settings.mixfactor <= 1.):

--- a/sktools/src/sktools/calculators/slateratom.py
+++ b/sktools/src/sktools/calculators/slateratom.py
@@ -87,7 +87,7 @@ class SlaterAtomSettings(sc.ClassDict):
         maxscfiter = query.getvalue(
             root, "maxscfiterations", converter=conv.int0, defvalue=120)
         mixer = query.getvalue(
-            root, "mixer", defvalue="broyden")
+            root, "mixer", defvalue="Broyden")
         mixfactor = query.getvalue(
             root, "mixingfactor", converter=conv.float0, defvalue=0.1)
         return cls(exponents, maxpowers, scftol, maxscfiter, mixer, mixfactor)

--- a/sktools/src/sktools/calculators/slateratom.py
+++ b/sktools/src/sktools/calculators/slateratom.py
@@ -21,6 +21,8 @@ SUPPORTED_FUNCTIONALS = {'lda' : 2, 'pbe' : 3, 'blyp' : 4, 'lcy-pbe' : 5,
                          'lcy-bnl' : 6, 'pbe0' : 7, 'b3lyp' : 8,
                          'camy-b3lyp' : 9, 'camy-pbeh' : 10}
 
+MIXER_TYPES = {'simple': 1, "broyden": 2, "diis": 3}
+
 INPUT_FILE = "slateratom.in"
 STDOUT_FILE = "output"
 DEFAULT_BINARY = "slateratom"
@@ -64,12 +66,14 @@ class SlaterAtomSettings(sc.ClassDict):
         Maximal power for every angular momentum.
     """
 
-    def __init__(self, exponents, maxpowers, scftol, maxscfiter):
+    def __init__(self, exponents, maxpowers, scftol, maxscfiter, mixer, mixfactor):
         super().__init__()
         self.exponents = exponents
         self.maxpowers = maxpowers
         self.scftol = scftol
         self.maxscfiter = maxscfiter
+        self.mixer = mixer
+        self.mixfactor = mixfactor
 
     @classmethod
     def fromhsd(cls, root, query):
@@ -81,7 +85,11 @@ class SlaterAtomSettings(sc.ClassDict):
             root, "scftolerance", converter=conv.float0, defvalue=1.0e-10)
         maxscfiter = query.getvalue(
             root, "maxscfiterations", converter=conv.int0, defvalue=120)
-        return cls(exponents, maxpowers, scftol, maxscfiter)
+        mixer = query.getvalue(
+            root, "mixer", defvalue="broyden")
+        mixfactor = query.getvalue(
+            root, "mixingfactor", converter=conv.float0, defvalue=0.1)
+        return cls(exponents, maxpowers, scftol, maxscfiter, mixer, mixfactor)
 
     def __eq__(self, other):
         if not isinstance(other, SlaterAtomSettings):
@@ -104,6 +112,10 @@ class SlaterAtomSettings(sc.ClassDict):
                 > sc.INPUT_FLOAT_TOLERANCE):
             return False
         if self.maxscfiter != other.maxscfiter:
+            return False
+        if self.mixer != other.mixer:
+            return False
+        if self.mixfactor != other.mixfactor:
             return False
         return True
 
@@ -159,6 +171,14 @@ class SlateratomInput:
         if len(settings.maxpowers) != atomconfig.maxang + 1:
             msg = "Slateratom: Missing STO max. powers for some shells"
             raise sc.SkgenException(msg)
+
+        if self._settings.mixer not in MIXER_TYPES:
+            msg = "SlaterAtom: unsupported mixer (must be either simple, Broyden, or DIIS)"
+            raise sc.SkgenException(msg)
+
+        if not (0. <= self._settings.mixfactor <= 1.):
+             msg = "Slateratom: SCF mixing factor must be between 0 and 1"
+             raise sc.SkgenException(msg)
 
         if self._settings.scftol <= 0.0:
             msg = "Slateratom: SCF tolerance must be >0.0 a.u."
@@ -365,8 +385,8 @@ class SlateratomInput:
 
         out.append("{:s} \t\t{:s} write eigenvectors".format(
             self._LOGICALSTRS[False], self._COMMENT))
-        out.append("{} {:g} \t\t\t{:s} broyden mixer, mixing factor".format(
-            2, 0.1, self._COMMENT))
+        out.append("{} {:g} \t\t\t{:s} mixer, mixing factor".format(
+            MIXER_TYPES[self._settings.mixer], self._settings.mixfactor, self._COMMENT))
 
         # Occupations
         for ll, occperl in enumerate(self._atomconfig.occupations):

--- a/sktools/src/sktools/calculators/slateratom.py
+++ b/sktools/src/sktools/calculators/slateratom.py
@@ -74,7 +74,6 @@ class SlaterAtomSettings(sc.ClassDict):
         self.maxscfiter = maxscfiter
         self.mixer = mixer
         self.mixfactor = mixfactor
-        print(self.__dict__)
 
     @classmethod
     def fromhsd(cls, root, query):

--- a/slateratom/lib/CMakeLists.txt
+++ b/slateratom/lib/CMakeLists.txt
@@ -31,6 +31,7 @@ set(sources-fpp
   blasroutines.F90
   broydenmixer.F90
   confinement.F90
+  diismixer.F90
   input.F90
   lapackroutines.F90
   simplemixer.F90

--- a/slateratom/lib/broydenmixer.F90
+++ b/slateratom/lib/broydenmixer.F90
@@ -48,11 +48,11 @@ module broydenmixer
     !> Weights for prev. iterations
     real(dp), allocatable :: ww(:)
 
-    !> Charge difference in last iteration
-    real(dp), allocatable :: qDiffLast(:)
+    !> Input increment in last iteration
+    real(dp), allocatable :: incrementLast(:)
 
-    !> Input charge in last iteration
-    real(dp), allocatable :: qInpLast(:)
+    !> Input quantity that is being mixed, last iteration
+    real(dp), allocatable :: inputLast(:)
 
     !> Storage for the "a" matrix
     real(dp), allocatable :: aa(:,:)
@@ -70,7 +70,7 @@ contains
 
   !> Creates a Broyden mixer instance.
   !! The weight associated with an iteration is calculated as weigthFac/ww where ww is the Euclidean
-  !! norm of the charge difference vector. If the calculated weigth is outside of the
+  !! norm of the quantity difference vector. If the calculated weigth is outside of the
   !! [minWeight, maxWeight] region it is replaced with the appropriate boundary value.
   subroutine TBroydenMixer_init(this, mIter, mixParam, omega0, minWeight, maxWeight, weightFac)
 
@@ -107,8 +107,8 @@ contains
     this%maxWeight = maxWeight
     this%weightFac = weightFac
     allocate(this%ww(mIter-1))
-    allocate(this%qInpLast(this%nElem))
-    allocate(this%qDiffLast(this%nElem))
+    allocate(this%inputLast(this%nElem))
+    allocate(this%incrementLast(this%nElem))
     allocate(this%aa(mIter-1, mIter-1))
     allocate(this%dF(this%nElem, mIter - 1))
     allocate(this%uu(this%nElem, mIter - 1))
@@ -129,10 +129,10 @@ contains
 
     if (nElem /= this%nElem) then
       this%nElem = nElem
-      deallocate(this%qInpLast)
-      deallocate(this%qDiffLast)
-      allocate(this%qInpLast(this%nElem))
-      allocate(this%qDiffLast(this%nElem))
+      deallocate(this%inputLast)
+      deallocate(this%incrementLast)
+      allocate(this%inputLast(this%nElem))
+      allocate(this%incrementLast(this%nElem))
       deallocate(this%dF)
       allocate(this%dF(this%nElem, this%mIter - 1))
       deallocate(this%uu)
@@ -153,24 +153,24 @@ contains
   !!   The restriction arises from the assumption that the dot-products of density matrices are
   !!   real-valued (imaginary parts add up to zero due to the hermitian property) and the linear
   !!   system of equations remains real-valued.
-  subroutine TBroydenMixer_mix(this, qInpResult, qDiff)
+  subroutine TBroydenMixer_mix(this, inputResult, increment)
 
     !> The Broyden mixer
     type(TBroydenMixer), intent(inout) :: this
 
     !> Input charges on entry, mixed charges on exit
-    real(dp), intent(inout) :: qInpResult(:)
+    real(dp), intent(inout) :: inputResult(:)
 
     !> Charge difference between output and input charges
-    real(dp), intent(in) :: qDiff(:)
+    real(dp), intent(in) :: increment(:)
 
     this%iIter = this%iIter + 1
     if (this%iIter > this%mIter) then
       error stop "Broyden mixer: Maximal nr. of steps exceeded"
     end if
 
-    call modifiedBroydenMixing(qInpResult, this%qInpLast, this%qDiffLast, this%aa,&
-        & this%ww, this%iIter, qDiff, this%alpha, this%omega0, this%minWeight, this%maxWeight,&
+    call modifiedBroydenMixing(inputResult, this%inputLast, this%incrementLast, this%aa,&
+        & this%ww, this%iIter, increment, this%alpha, this%omega0, this%minWeight, this%maxWeight,&
         & this%weightFac, this%nElem, this%dF, this%uu)
 
   end subroutine TBroydenMixer_mix

--- a/slateratom/lib/diagonalizations.f90
+++ b/slateratom/lib/diagonalizations.f90
@@ -14,7 +14,7 @@ contains
 
   !> Diagonalizes overlap matrix to check for linear dependency of basis set.
   !! Implicitely LAPACK's dsyev is called.
-  subroutine diagonalize_overlap(max_l, num_alpha, poly_order, ss)
+  subroutine diagonalize_overlap(max_l, num_alpha, poly_order, ss, invsqrt_ss)
 
     !> maximum angular momentum
     integer, intent(in) :: max_l
@@ -28,6 +28,9 @@ contains
     !> overlap supervector
     real(dp), intent(in) :: ss(0:, :,:)
 
+    !> inv. sqrt. of the overlap supervector
+    real(dp), intent(inout) :: invsqrt_ss(0:, :,:)
+
     !! overlap matrices
     real(dp), allocatable :: overlap(:,:)
 
@@ -35,7 +38,7 @@ contains
     real(dp), allocatable :: eigenvalues(:)
 
     !> auxiliary variables
-    integer :: ll, diagsize
+    integer :: ll, diagsize, ii
 
     do ll = 0, max_l
 
@@ -46,7 +49,7 @@ contains
 
       overlap = ss(ll, :,:)
 
-      call heev(overlap, eigenvalues, 'U', 'N')
+      call heev(overlap, eigenvalues, 'U', 'V')
 
       write(*, '(A,I3,A,E16.8)') 'Smallest eigenvalue of overlap for l= ', ll, ' : ', eigenvalues(1)
 
@@ -56,6 +59,12 @@ contains
         write(*, '(A)') ' '
         stop
       end if
+
+      ! compute S^(-1/2)
+      do ii = 1, diagsize
+        invsqrt_ss(ll, ii, ii) = eigenvalues(ii)**(-1.0_dp / 2)
+      end do
+      invsqrt_ss(ll,:,:) = matmul(overlap, matmul(invsqrt_ss(ll,:,:), transpose(overlap)))
 
       deallocate(overlap, eigenvalues)
 

--- a/slateratom/lib/diismixer.F90
+++ b/slateratom/lib/diismixer.F90
@@ -1,0 +1,256 @@
+#:include 'common.fypp'
+
+!> Contains the DIIS mixer
+!! The DIIS mixing is done by building a weighted combination over the previous input charges to
+!! minimise the residue of the error.
+!! Only a specified number of previous charge vectors are considered.
+!! The modification based on from Kovalenko et al. (J. Comput. Chem., 20: 928-936 1999) and Patrick
+!! Briddon to add a contribution from the gradient vector as well is also used.
+!! In order to use the mixer you have to create and reset it.
+!!
+!! Code is adapted from DFTB+.
+module diismixer
+  use common_accuracy, only : dp
+  use lapackroutines, only : gesv
+  use mixer, only : TMixer
+  implicit none
+
+  private
+
+  public :: TDiisMixerInp
+  public :: TDiisMixer, TDiisMixer_init, TDiisMixer_mix, TDiisMixer_reset
+
+  type :: TDiisMixerInp
+    !> Nr. of generations (including actual) to consider
+    integer :: iGenerations = 0
+
+    !> Mixing parameter for the first iGenerations cycles
+    real(dp) :: initMixParam = 0.0_dp
+
+    !> True if using DIIS from iteration 2 as well as mixing
+    logical :: tFromStart = .true.
+
+    !> If > 0, fraction of extrapolated downhill direction to include in DIIS space
+    real(dp) :: alpha = 0.0_dp
+
+  end type TDiisMixerInp
+
+  !> Contains the necessary data for an DIIS mixer.
+  type, extends (TMixer) :: TDiisMixer
+    private
+
+    !> Initial mixing parameter
+    real(dp) :: initMixParam
+
+    !> Max. nr. of stored prev. vectors
+    integer :: mPrevVector
+
+    !> Nr. of stored previous vectors
+    integer :: iPrevVector
+
+    !> Nr. of elements in the vectors
+    integer :: nElem
+
+    !> Index for the storage
+    integer :: indx
+
+    !> Stored previous input charges
+    real(dp), allocatable :: prevQInput(:,:)
+
+    !> Stored prev. charge differences
+    real(dp), allocatable :: prevQDiff(:,:)
+
+    !> True if DIIS used from iteration 2 as well as mixing
+    logical :: tFromStart
+
+    !> Force modification for gDIIS?
+    logical :: tAddIntrpGradient
+
+    !> Alpha factor to add in new information
+    real(dp) :: alpha
+
+    !> Holds DIIS mixed gradients from older iterations for downhill direction
+    real(dp), allocatable :: deltaR(:)
+
+    contains
+      procedure :: reset => TDiisMixer_reset
+      procedure :: mix1D => TDiisMixer_mix
+  end type TDiisMixer
+
+contains
+
+  !> Initializes a DIIS mixer instance.
+  subroutine TDiisMixer_init(this, mixerInp)
+
+    !> Pointer to an initialized DIIS mixer on exit
+    type(TDiisMixer), intent(out) :: this
+
+    !> TDiisMixer input structure
+    type(TDiisMixerInp), intent(in) :: mixerInp
+
+    @:ASSERT(mixerInp%iGenerations >= 2)
+
+    this%nElem = 0
+    this%mPrevVector = mixerInp%iGenerations
+
+    allocate(this%prevQInput(this%nElem, this%mPrevVector))
+    allocate(this%prevQDiff(this%nElem, this%mPrevVector))
+
+    this%initMixParam = mixerInp%initMixParam
+    this%tFromStart = mixerInp%tFromStart
+
+
+    if (mixerInp%alpha > 0.0_dp) then
+      this%tAddIntrpGradient = .true.
+      this%alpha = mixerInp%alpha
+      allocate(this%deltaR(this%nElem))
+    else
+      this%tAddIntrpGradient = .false.
+      this%alpha = 0.0_dp
+      allocate(this%deltaR(0))
+    end if
+
+    this%deltaR(:) = 0.0_dp
+
+  end subroutine TDiisMixer_init
+
+
+  !> Makes the mixer ready for a new SCC cycle.
+  subroutine TDiisMixer_reset(this, nElem)
+
+    !> DIIS mixer instance
+    class(TDiisMixer), intent(inout) :: this
+
+    !> Nr. of elements in the vectors to mix
+    integer, intent(in) :: nElem
+
+    @:ASSERT(nElem > 0)
+
+    if (nElem /= this%nElem) then
+      this%nElem = nElem
+      deallocate(this%prevQInput)
+      deallocate(this%prevQDiff)
+      allocate(this%prevQInput(this%nElem, this%mPrevVector))
+      allocate(this%prevQDiff(this%nElem, this%mPrevVector))
+      if (this%tAddIntrpGradient) then
+        deallocate(this%deltaR)
+        allocate(this%deltaR(this%nElem))
+        this%deltaR(:) = 0.0_dp
+      end if
+    end if
+    this%iPrevVector = 0
+    this%indx = 0
+
+  end subroutine TDiisMixer_reset
+
+
+  !> Mixes charges according to the DIIS method.
+  subroutine TDiisMixer_mix(this, qInpResult, qDiff)
+
+    !> Pointer to the diis mixer
+    class(TDiisMixer), intent(inout) :: this
+
+    !> Input charges on entry, mixed charges on exit.
+    real(dp), intent(inout) :: qInpResult(:)
+
+    !> Charge difference vector between output and input charges
+    real(dp), intent(in) :: qDiff(:)
+
+    real(dp), allocatable :: aa(:,:), bb(:,:)
+    integer :: ii, jj
+
+    @:ASSERT(size(qInpResult) == this%nElem)
+    @:ASSERT(size(qDiff) == this%nElem)
+
+    if (this%iPrevVector < this%mPrevVector) then
+      this%iPrevVector = this%iPrevVector + 1
+    end if
+
+    call storeVectors(this%prevQInput, this%prevQDiff, this%indx, qInpResult, qDiff,&
+        & this%mPrevVector)
+
+    if (this%tFromStart .or. this%iPrevVector == this%mPrevVector) then
+
+      allocate(aa(this%iPrevVector + 1, this%iPrevVector + 1))
+      allocate(bb(this%iPrevVector + 1, 1))
+
+      aa(:,:) = 0.0_dp
+      bb(:,:) = 0.0_dp
+
+      ! (due to the hermitian property of our density matrices, the dot-product below is real)
+      do ii = 1, this%iPrevVector
+        do jj = 1, this%iPrevVector
+          aa(ii, jj) = dot_product(this%prevQDiff(:, ii), this%prevQDiff(:, jj))
+        end do
+      end do
+      aa(this%iPrevVector + 1, 1:this%iPrevVector) = -1.0_dp
+      aa(1:this%iPrevVector, this%iPrevVector + 1) = -1.0_dp
+
+      bb(this%iPrevVector + 1, 1) = -1.0_dp
+
+      ! Solve DIIS system of linear equations
+      call gesv(aa, bb)
+
+      qInpResult(:) = 0.0_dp
+      do ii = 1, this%iPrevVector
+        qInpResult(:) = qInpResult + bb(ii, 1) * (this%prevQInput(:, ii) + this%prevQDiff(:, ii))
+      end do
+
+      if (this%tAddIntrpGradient) then
+        ! old DIIS estimate for downhill direction points towards current downhill direction as well
+        ! as the actual vector, based on P. Briddon comments
+        if (abs(dot_product(this%deltaR, qDiff)) > 0.0_dp) then
+          ! mix in larger amounts of the gradient in future
+          this%alpha = 1.5_dp * this%alpha
+        else
+          ! points the other way, mix in less
+          this%alpha = 0.5 * this%alpha
+        end if
+
+        ! add a fraction down the DIIS estimated gradient onto the new solution
+        this%deltaR(:) = 0.0_dp
+        do ii = 1, this%iPrevVector
+          this%deltaR(:) = this%deltaR + bb(ii, 1) * this%prevQDiff(:, ii)
+        end do
+        qInpResult(:) = qInpResult - this%alpha * this%deltaR
+      end if
+
+    end if
+
+    if (this%iPrevVector < this%mPrevVector) then
+      ! First few iterations return simple mixed vector
+      qInpResult(:) = qInpResult + this%initMixParam * qDiff
+    end if
+
+  end subroutine TDiisMixer_mix
+
+
+  !> Stores a vector pair in a limited storage.
+  !! If the stack is full, oldest vector pair is overwritten.
+  subroutine storeVectors(prevQInp, prevQDiff, indx, qInput, qDiff, mPrevVector)
+
+    !> Contains previous vectors of the first type
+    real(dp), intent(inout) :: prevQInp(:,:)
+
+    !> Contains previous vectors of the second type
+    real(dp), intent(inout) :: prevQDiff(:,:)
+
+    !> Indexing of data
+    integer, intent(inout) :: indx
+
+    !> New first vector
+    real(dp), intent(in) :: qInput(:)
+
+    !> New second vector
+    real(dp), intent(in) :: qDiff(:)
+
+    !> Size of the stacks.
+    integer, intent(in) :: mPrevVector
+
+    indx = mod(indx, mPrevVector) + 1
+    prevQInp(:, indx) = qInput
+    prevQDiff(:, indx) = qDiff
+
+  end subroutine storeVectors
+
+end module diismixer

--- a/slateratom/lib/diismixer.F90
+++ b/slateratom/lib/diismixer.F90
@@ -16,23 +16,7 @@ module diismixer
 
   private
 
-  public :: TDiisMixerInp
   public :: TDiisMixer, TDiisMixer_init, TDiisMixer_mix, TDiisMixer_reset
-
-  type :: TDiisMixerInp
-    !> Nr. of generations (including actual) to consider
-    integer :: iGenerations = 0
-
-    !> Mixing parameter for the first iGenerations cycles
-    real(dp) :: initMixParam = 0.0_dp
-
-    !> True if using DIIS from iteration 2 as well as mixing
-    logical :: tFromStart = .true.
-
-    !> If > 0, fraction of extrapolated downhill direction to include in DIIS space
-    real(dp) :: alpha = 0.0_dp
-
-  end type TDiisMixerInp
 
   !> Contains the necessary data for an DIIS mixer.
   type TDiisMixer
@@ -53,23 +37,20 @@ module diismixer
     !> Index for the storage
     integer :: indx
 
-    !> Stored previous input charges
-    real(dp), allocatable :: prevQInput(:,:)
+    !> Stored previous input quantities
+    real(dp), allocatable :: prevInput(:,:)
 
-    !> Stored prev. charge differences
-    real(dp), allocatable :: prevQDiff(:,:)
+    !> Stored differences of previous input quantities
+    real(dp), allocatable :: prevIncrement(:,:)
+
+    !> Stored prev. error vectors
+    real(dp), allocatable :: prevErrorVec(:,:)
 
     !> True if DIIS used from iteration 2 as well as mixing
     logical :: tFromStart
 
-    !> Force modification for gDIIS?
-    logical :: tAddIntrpGradient
-
     !> Alpha factor to add in new information
     real(dp) :: alpha
-
-    !> Holds DIIS mixed gradients from older iterations for downhill direction
-    real(dp), allocatable :: deltaR(:)
 
     contains
       procedure :: reset => TDiisMixer_reset
@@ -79,37 +60,31 @@ module diismixer
 contains
 
   !> Initializes a DIIS mixer instance.
-  subroutine TDiisMixer_init(this, mixerInp)
+  subroutine TDiisMixer_init(this, iGenerations, initMixParam, tFromStart)
 
     !> Pointer to an initialized DIIS mixer on exit
     type(TDiisMixer), intent(out) :: this
 
-    !> TDiisMixer input structure
-    type(TDiisMixerInp), intent(in) :: mixerInp
+    !> Number of generations to consider (including current)
+    integer, intent(in) :: iGenerations
 
-    @:ASSERT(mixerInp%iGenerations >= 2)
+    !> Damping parameter for the first mixing steps
+    real(dp), intent(in) :: initMixParam
+
+    !> Use DIIS from step 2 onwards?
+    logical, intent(in) :: tFromStart
+
+    @:ASSERT(iGenerations >= 2)
 
     this%nElem = 0
-    this%mPrevVector = mixerInp%iGenerations
+    this%mPrevVector = iGenerations
 
-    allocate(this%prevQInput(this%nElem, this%mPrevVector))
-    allocate(this%prevQDiff(this%nElem, this%mPrevVector))
+    allocate(this%prevInput(this%nElem, this%mPrevVector))
+    allocate(this%prevErrorVec(this%nElem, this%mPrevVector))
+    allocate(this%prevIncrement(this%nElem, this%mPrevVector))
 
-    this%initMixParam = mixerInp%initMixParam
-    this%tFromStart = mixerInp%tFromStart
-
-
-    if (mixerInp%alpha > 0.0_dp) then
-      this%tAddIntrpGradient = .true.
-      this%alpha = mixerInp%alpha
-      allocate(this%deltaR(this%nElem))
-    else
-      this%tAddIntrpGradient = .false.
-      this%alpha = 0.0_dp
-      allocate(this%deltaR(0))
-    end if
-
-    this%deltaR(:) = 0.0_dp
+    this%initMixParam = initMixParam
+    this%tFromStart = tFromStart
 
   end subroutine TDiisMixer_init
 
@@ -127,15 +102,12 @@ contains
 
     if (nElem /= this%nElem) then
       this%nElem = nElem
-      deallocate(this%prevQInput)
-      deallocate(this%prevQDiff)
-      allocate(this%prevQInput(this%nElem, this%mPrevVector))
-      allocate(this%prevQDiff(this%nElem, this%mPrevVector))
-      if (this%tAddIntrpGradient) then
-        deallocate(this%deltaR)
-        allocate(this%deltaR(this%nElem))
-        this%deltaR(:) = 0.0_dp
-      end if
+      deallocate(this%prevInput)
+      deallocate(this%prevErrorVec)
+      deallocate(this%prevIncrement)
+      allocate(this%prevInput(this%nElem, this%mPrevVector))
+      allocate(this%prevErrorVec(this%nElem, this%mPrevVector))
+      allocate(this%prevIncrement(this%nElem, this%mPrevVector))
     end if
     this%iPrevVector = 0
     this%indx = 0
@@ -143,31 +115,34 @@ contains
   end subroutine TDiisMixer_reset
 
 
-  !> Mixes charges according to the DIIS method.
-  subroutine TDiisMixer_mix(this, qInpResult, qDiff)
+  !> Mixes quantities according to the DIIS method.
+  subroutine TDiisMixer_mix(this, inputResult, inputIncrement, errorVector)
 
     !> Pointer to the diis mixer
     class(TDiisMixer), intent(inout) :: this
 
-    !> Input charges on entry, mixed charges on exit.
-    real(dp), intent(inout) :: qInpResult(:)
+    !> Input quantity on entry, mixed quantity on exit.
+    real(dp), intent(inout) :: inputResult(:)
 
-    !> Charge difference vector between output and input charges
-    real(dp), intent(in) :: qDiff(:)
+    !> Increment vector between input and output quantities
+    real(dp), intent(in) :: inputIncrement(:)
+
+    !> Error metric vector
+    real(dp), intent(in) :: errorVector(:)
+
 
     real(dp), allocatable :: aa(:,:), bb(:,:)
     integer :: ii, jj
 
-    @:ASSERT(size(qInpResult) == this%nElem)
-    @:ASSERT(size(qDiff) == this%nElem)
+    @:ASSERT(size(inputResult) == this%nElem)
+    @:ASSERT(size(errorVector) == this%nElem)
 
     if (this%iPrevVector < this%mPrevVector) then
       this%iPrevVector = this%iPrevVector + 1
     end if
 
-    call storeVectors(this%prevQInput, this%prevQDiff, this%indx, qInpResult, qDiff,&
-        & this%mPrevVector)
-
+    call storeVectors(this%prevInput, this%prevIncrement, this%prevErrorVec, this%indx,&
+        & inputResult, inputIncrement, errorVector, this%mPrevVector)
     if (this%tFromStart .or. this%iPrevVector == this%mPrevVector) then
 
       allocate(aa(this%iPrevVector + 1, this%iPrevVector + 1))
@@ -179,7 +154,7 @@ contains
       ! (due to the hermitian property of our density matrices, the dot-product below is real)
       do ii = 1, this%iPrevVector
         do jj = 1, this%iPrevVector
-          aa(ii, jj) = dot_product(this%prevQDiff(:, ii), this%prevQDiff(:, jj))
+          aa(ii, jj) = dot_product(this%prevErrorVec(:, ii), this%prevErrorVec(:, jj))
         end do
       end do
       aa(this%iPrevVector + 1, 1:this%iPrevVector) = -1.0_dp
@@ -190,35 +165,16 @@ contains
       ! Solve DIIS system of linear equations
       call gesv(aa, bb)
 
-      qInpResult(:) = 0.0_dp
+      inputResult(:) = 0.0_dp
       do ii = 1, this%iPrevVector
-        qInpResult(:) = qInpResult + bb(ii, 1) * (this%prevQInput(:, ii) + this%prevQDiff(:, ii))
+        inputResult(:) = inputResult + bb(ii, 1) * (this%prevInput(:, ii) + this%prevIncrement(:, ii))
       end do
-
-      if (this%tAddIntrpGradient) then
-        ! old DIIS estimate for downhill direction points towards current downhill direction as well
-        ! as the actual vector, based on P. Briddon comments
-        if (abs(dot_product(this%deltaR, qDiff)) > 0.0_dp) then
-          ! mix in larger amounts of the gradient in future
-          this%alpha = 1.5_dp * this%alpha
-        else
-          ! points the other way, mix in less
-          this%alpha = 0.5 * this%alpha
-        end if
-
-        ! add a fraction down the DIIS estimated gradient onto the new solution
-        this%deltaR(:) = 0.0_dp
-        do ii = 1, this%iPrevVector
-          this%deltaR(:) = this%deltaR + bb(ii, 1) * this%prevQDiff(:, ii)
-        end do
-        qInpResult(:) = qInpResult - this%alpha * this%deltaR
-      end if
 
     end if
 
     if (this%iPrevVector < this%mPrevVector) then
       ! First few iterations return simple mixed vector
-      qInpResult(:) = qInpResult + this%initMixParam * qDiff
+      inputResult(:) = inputResult + this%initMixParam * inputIncrement(:)
     end if
 
   end subroutine TDiisMixer_mix
@@ -226,30 +182,38 @@ contains
 
   !> Stores a vector pair in a limited storage.
   !! If the stack is full, oldest vector pair is overwritten.
-  subroutine storeVectors(prevQInp, prevQDiff, indx, qInput, qDiff, mPrevVector)
+  subroutine storeVectors(prevInp, prevIncrement, prevErrorVector, indx, input, increment,&
+        & errorVector, mPrevVector)
 
     !> Contains previous vectors of the first type
-    real(dp), intent(inout) :: prevQInp(:,:)
+    real(dp), intent(inout) :: prevInp(:,:)
 
     !> Contains previous vectors of the second type
-    real(dp), intent(inout) :: prevQDiff(:,:)
+    real(dp), intent(inout) :: prevErrorVector(:,:)
+
+    !> Contains previous differences of vectors of first type
+    real(dp), intent(inout) :: prevIncrement(:,:)
 
     !> Indexing of data
     integer, intent(inout) :: indx
 
     !> New first vector
-    real(dp), intent(in) :: qInput(:)
+    real(dp), intent(in) :: input(:)
+
+    !> New increment of first vector
+    real(dp), intent(in) :: increment(:)
 
     !> New second vector
-    real(dp), intent(in) :: qDiff(:)
+    real(dp), intent(in) :: errorVector(:)
 
     !> Size of the stacks.
     integer, intent(in) :: mPrevVector
 
     indx = mod(indx, mPrevVector) + 1
-    prevQInp(:, indx) = qInput
-    prevQDiff(:, indx) = qDiff
-
+    prevInp(:, indx) = input
+    prevIncrement(:, indx) = increment
+    prevErrorVector(:, indx) = errorVector
+    
   end subroutine storeVectors
 
 end module diismixer

--- a/slateratom/lib/diismixer.F90
+++ b/slateratom/lib/diismixer.F90
@@ -12,7 +12,6 @@
 module diismixer
   use common_accuracy, only : dp
   use lapackroutines, only : gesv
-  use mixer, only : TMixer
   implicit none
 
   private
@@ -36,7 +35,7 @@ module diismixer
   end type TDiisMixerInp
 
   !> Contains the necessary data for an DIIS mixer.
-  type, extends (TMixer) :: TDiisMixer
+  type TDiisMixer
     private
 
     !> Initial mixing parameter

--- a/slateratom/lib/globals.f90
+++ b/slateratom/lib/globals.f90
@@ -5,6 +5,7 @@ module globals
   use mixer, only : TMixer, TMixer_init, TMixer_reset, mixerTypes
   use broydenmixer, only : TBroydenMixer, TBroydenMixer_init
   use simplemixer, only : TSimpleMixer, TSimpleMixer_init
+  use diismixer, only : TDiisMixer, TDiisMixer_init
   use confinement, only : TConfInp
 
   implicit none
@@ -202,6 +203,9 @@ module globals
   !> broyden mixer (if used)
   type(TBroydenMixer), allocatable :: pBroydenMixer
 
+  !> DIIS mixer (if used)
+  type(TDiisMixer), allocatable :: pDiisMixer
+
   !> mixing factor
   real(dp) :: mixing_factor
 
@@ -292,6 +296,10 @@ contains
       call TBroydenMixer_init(pBroydenMixer, maxiter, mixing_factor, 0.01_dp, 1.0_dp, 1.0e5_dp,&
           & 1.0e-2_dp)
       call TMixer_init(pMixer, pBroydenMixer)
+    case(mixerTypes%diis)
+      allocate(pDiisMixer)
+      call TDiisMixer_init(pDiisMixer, 5, mixing_factor, .true.)
+      call TMixer_init(pMixer, pDiisMixer)
     case default
       error stop "Unknown mixer type."
     end select

--- a/slateratom/lib/globals.f90
+++ b/slateratom/lib/globals.f90
@@ -298,7 +298,7 @@ contains
       call TMixer_init(pMixer, pBroydenMixer)
     case(mixerTypes%diis)
       allocate(pDiisMixer)
-      call TDiisMixer_init(pDiisMixer, 5, mixing_factor, .true.)
+      call TDiisMixer_init(pDiisMixer, 10, mixing_factor, .false.)
       call TMixer_init(pMixer, pDiisMixer)
     case default
       error stop "Unknown mixer type."

--- a/slateratom/lib/globals.f90
+++ b/slateratom/lib/globals.f90
@@ -61,6 +61,9 @@ module globals
   !> overlap supervector
   real(dp), allocatable :: ss(:,:,:)
 
+  !> inv. square root of the overlap supervector
+  real(dp), allocatable :: invsqrt_ss(:,:,:)
+
   !> nucleus-electron supervector
   real(dp), allocatable :: uu(:,:,:)
 
@@ -85,8 +88,14 @@ module globals
   !> wavefunction coefficients
   real(dp), allocatable :: cof(:,:,:,:)
 
-  !> relative changes during scf
-  real(dp) :: change_max
+  !> max abs. change in potential matrix in the last scf step
+  real(dp) :: d_pot_max
+
+  !> max abs. change in occupied Fock eigenvalues in the last scf step
+  real(dp) :: d_spectrum_max
+
+  !> max abs. value in the commutator from the current scf step
+  real(dp) :: commutator_max
 
   !> density matrix supervector
   real(dp), allocatable :: pp(:,:,:,:)
@@ -94,14 +103,20 @@ module globals
   !> fock matrix supervector
   real(dp), allocatable :: ff(:,:,:,:)
 
+  !> commutator [F, PS]
+  real(dp), allocatable :: commutator(:,:,:,:)
+
   !> potential matrix supervectors
   real(dp), allocatable :: pot_new(:,:,:,:), pot_old(:,:,:,:)
 
   !> eigenvalues
-  real(dp), allocatable :: eigval(:,:,:)
+  real(dp), allocatable :: eigval(:,:,:), eigval_old(:,:,:)
 
   !> zora scaled eigenvalues
   real(dp), allocatable :: eigval_scaled(:,:,:)
+
+  !> true, if SCF cycle reached convergency on a given quantity
+  logical :: tCommutatorConverged, tEnergyConverged, tSpectrumConverged
 
   !> total energy
   real(dp) :: total_ene
@@ -220,16 +235,19 @@ contains
 
     allocate(ss(0:max_l, problemsize, problemsize))
     write(*, '(A,I0,A)') 'Size of one Supervectors is ', size(ss), ' double precision elements'
+    allocate(invsqrt_ss(0:max_l, problemsize, problemsize))
 
     allocate(uu(0:max_l, problemsize, problemsize))
     allocate(tt(0:max_l, problemsize, problemsize))
     allocate(vconf(num_mesh_points, 0:max_l))
     allocate(vconf_matrix(0:max_l, problemsize, problemsize))
     allocate(ff(2, 0:max_l, problemsize, problemsize))
+    allocate(commutator(2, 0:max_l, problemsize, problemsize))
     allocate(pot_old(2, 0:max_l, problemsize, problemsize))
     allocate(pot_new(2, 0:max_l, problemsize, problemsize))
 
     allocate(eigval(2, 0:max_l, problemsize))
+    allocate(eigval_old(2, 0:max_l, problemsize))
     allocate(eigval_scaled(2, 0:max_l, problemsize))
 
     allocate(jj(0:max_l, problemsize, problemsize, 0:max_l, problemsize, problemsize))
@@ -253,6 +271,7 @@ contains
     ddrho(:,:) = 0.0_dp
 
     eigval(:,:,:) = 0.0_dp
+    eigval_old(:,:,:) = 0.0_dp
     eigval_scaled(:,:,:) = 0.0_dp
 
     cof(:,:,:,:) = 0.0_dp

--- a/slateratom/lib/hamiltonian.f90
+++ b/slateratom/lib/hamiltonian.f90
@@ -3,7 +3,7 @@ module hamiltonian
 
   use common_accuracy, only : dp
   use dft, only : dft_exc_matrixelement
-  use mixer, only : TMixer, TMixer_mix
+  use mixer, only : TMixer, TMixer_mix, TMixer_getMixerType
   use zora_routines, only : zora_t_correction
   use xcfunctionals, only : xcFunctional
 
@@ -19,7 +19,7 @@ contains
   !> Main driver routine for Fock matrix build-up. Also calls mixer with potential matrix.
   subroutine build_hamiltonian(pMixer, iScf, tt, uu, nuc, vconf, jj, kk, kk_lr, pp, max_l,&
       & num_alpha, poly_order, problemsize, xcnr, num_mesh_points, weight, abcissa, vxc, alpha,&
-      & pot_old, pot_new, tZora, ff, camAlpha, camBeta)
+      & pot_old, pot_new, commutator, tZora, ff, camAlpha, camBeta)
 
     !> mixer instances
     type(TMixer), intent(inout) :: pMixer
@@ -86,6 +86,9 @@ contains
 
     !> new potential
     real(dp), intent(out) :: pot_new(:,0:,:,:)
+
+    !> commutator [F,PS]
+    real(dp), intent(out) :: commutator(:, 0:, :, :)
 
     !> true, if zero-order regular approximation for relativistic effects is desired
     logical, intent(in) :: tZora

--- a/slateratom/lib/hamiltonian.f90
+++ b/slateratom/lib/hamiltonian.f90
@@ -4,8 +4,9 @@ module hamiltonian
   use common_accuracy, only : dp
   use dft, only : dft_exc_matrixelement
   use mixer, only : TMixer, TMixer_mix, TMixer_getMixerType
-  use zora_routines, only : zora_t_correction
+  use utilities, only : compute_commutator
   use xcfunctionals, only : xcFunctional
+  use zora_routines, only : zora_t_correction
 
   implicit none
   private
@@ -19,7 +20,7 @@ contains
   !> Main driver routine for Fock matrix build-up. Also calls mixer with potential matrix.
   subroutine build_hamiltonian(pMixer, iScf, tt, uu, nuc, vconf, jj, kk, kk_lr, pp, max_l,&
       & num_alpha, poly_order, problemsize, xcnr, num_mesh_points, weight, abcissa, vxc, alpha,&
-      & pot_old, pot_new, commutator, tZora, ff, camAlpha, camBeta)
+      & pot_old, pot_new, overlap, invsqrt_ss, commutator, tZora, ff, camAlpha, camBeta)
 
     !> mixer instances
     type(TMixer), intent(inout) :: pMixer
@@ -86,6 +87,12 @@ contains
 
     !> new potential
     real(dp), intent(out) :: pot_new(:,0:,:,:)
+
+    !> Overlap matrix S
+    real(dp), intent(in) :: overlap(0:, :,:)
+    
+    !> S^(-1/2)
+    real(dp), intent(in) :: invsqrt_ss(0:, :,:)
 
     !> commutator S^(-1/2) [F,PS] S^(-1/2)
     real(dp), intent(out) :: commutator(:, 0:, :, :)
@@ -182,9 +189,45 @@ contains
     pot_new(1, :,:,:) = - real(nuc, dp) * uu + j_matrix - k_matrix(1, :,:,:)
     pot_new(2, :,:,:) = - real(nuc, dp) * uu + j_matrix - k_matrix(2, :,:,:)
 
+    ! pre-build Fock matrix for commutator computation
+    do ii = 0, max_l
+      ss = 0
+      do jjj = 1, num_alpha(ii)
+        do kkk = 1, poly_order(ii)
+          ss = ss + 1
+          ttt = 0
+          do ll = 1, num_alpha(ii)
+            do mm = 1, poly_order(ii)
+              ttt = ttt + 1
+
+              ff(1, ii, ss, ttt) = tt(ii, ss, ttt) + pot_new(1, ii, ss, ttt) + vconf(ii, ss, ttt)
+              ff(2, ii, ss, ttt) = tt(ii, ss, ttt) + pot_new(2, ii, ss, ttt) + vconf(ii, ss, ttt)
+
+              if (tZora) then
+                ff(1, ii, ss, ttt) = ff(1, ii, ss, ttt) + t_zora(1, ii, ss, ttt)
+                ff(2, ii, ss, ttt) = ff(2, ii, ss, ttt) + t_zora(2, ii, ss, ttt)
+              end if
+
+            end do
+          end do
+        end do
+      end do
+    end do
+
+    ! compute S^(-1/2) [F,PS] S^(-1/2)
+    call compute_commutator(max_l, num_alpha, poly_order, ff, pp, overlap, invsqrt_ss, commutator)
+
+    ! Not sure: before or after mixer (potential .ne. Matrix elements)?
+    ! Should be irrelevant once self-consistency is reached.
+    if (tZora .and. (iScf /= 0)) then
+      call zora_t_correction(1, t_zora, max_l, num_alpha, alpha, poly_order, num_mesh_points,&
+          & weight, abcissa, vxc, nuc, pp, problemsize)
+    end if
+
     ! mixer
     allocate(pot_diff, mold=pot_old)
     pot_diff(:,0:,:,:) = pot_old - pot_new
+
     call TMixer_mix(pMixer, pot_new, pot_diff, commutator)
 
     ! Not sure: before or after mixer (potential .ne. Matrix elements)?
@@ -218,6 +261,8 @@ contains
         end do
       end do
     end do
+
+   deallocate(pot_diff)
 
   end subroutine build_hamiltonian
 

--- a/slateratom/lib/hamiltonian.f90
+++ b/slateratom/lib/hamiltonian.f90
@@ -87,7 +87,7 @@ contains
     !> new potential
     real(dp), intent(out) :: pot_new(:,0:,:,:)
 
-    !> commutator [F,PS]
+    !> commutator S^(-1/2) [F,PS] S^(-1/2)
     real(dp), intent(out) :: commutator(:, 0:, :, :)
 
     !> true, if zero-order regular approximation for relativistic effects is desired
@@ -185,7 +185,7 @@ contains
     ! mixer
     allocate(pot_diff, mold=pot_old)
     pot_diff(:,0:,:,:) = pot_old - pot_new
-    call TMixer_mix(pMixer, pot_new, pot_diff)
+    call TMixer_mix(pMixer, pot_new, pot_diff, commutator)
 
     ! Not sure: before or after mixer (potential .ne. Matrix elements)?
     ! Should be irrelevant once self-consistency is reached.

--- a/slateratom/lib/hamiltonian.f90
+++ b/slateratom/lib/hamiltonian.f90
@@ -3,7 +3,7 @@ module hamiltonian
 
   use common_accuracy, only : dp
   use dft, only : dft_exc_matrixelement
-  use mixer, only : TMixer, TMixer_mix, TMixer_getMixerType
+  use mixer, only : TMixer, TMixer_mix, TMixer_getMixerType, TMixer_reset
   use utilities, only : compute_commutator
   use xcfunctionals, only : xcFunctional
   use zora_routines, only : zora_t_correction
@@ -226,9 +226,15 @@ contains
 
     ! mixer
     allocate(pot_diff, mold=pot_old)
-    pot_diff(:,0:,:,:) = pot_old - pot_new
+    ! pot_diff(:,0:,:,:) = pot_old - pot_new
+    pot_diff(:,0:,:,:) = pot_new - pot_old
 
     call TMixer_mix(pMixer, pot_new, pot_diff, commutator)
+
+    ! guard against uninitalised arrays on step 0
+    if (iScf == 0) then
+      call TMixer_reset(pMixer, size(pot_new))
+    end if
 
     ! Not sure: before or after mixer (potential .ne. Matrix elements)?
     ! Should be irrelevant once self-consistency is reached.

--- a/slateratom/lib/input.F90
+++ b/slateratom/lib/input.F90
@@ -252,7 +252,7 @@ contains
     read(*,*) tPrintEigvecs
 
     write(*, '(A)') 'Enter mixer and mixing parameter <1:&
-        & 1: Simple mixer, 2: Broyden mixer'
+        & 1: Simple mixer, 2: Broyden mixer, 3: DIIS'
     read(*,*) mixnr, mixing_factor
 
   end subroutine read_input_1

--- a/slateratom/lib/lapackroutines.F90
+++ b/slateratom/lib/lapackroutines.F90
@@ -5,10 +5,12 @@
 module lapackroutines
 
   use common_accuracy, only : dp, rdp
+  use common_message, only : error
+  
   implicit none
 
   private
-  public :: getrf, getrs
+  public :: gesv, getrf, getrs
 
 
   !> Computes the LU decomposition of a general rectangular matrix using partial pivoting with row
@@ -29,7 +31,69 @@ module lapackroutines
   end interface getrs
 
 
+  !> Computes the solution to a real system of linear equations A * X = B, where A is an N-by-N
+  !> matrix and X and B are N-by-NRHS matrices
+  interface gesv
+    module procedure gesv_dble
+  end interface gesv
+
 contains
+
+  !> Solves a general system of linear equations A * X = B, where A is a real matrix.
+  subroutine gesv_dble(aa, bb, nEquation, nSolution)
+
+    !> Contains the coefficients on entry, the LU factorisation on exit.
+    real(dp), intent(inout) :: aa(:,:)
+
+    !> Right hand side(s) of the linear equation on entry, solution(s) on exit.
+    real(dp), intent(inout) :: bb(:,:)
+
+    !> The size of the problem (nr. of variables and equations). Must be only specified if different
+    !> from size(aa, dim=1).
+    integer, intent(in), optional :: nEquation
+
+    !> Nr. of right hand sides (nr. of solutions). Must be only specified if different from size(b,
+    !> dim=2).
+    integer, intent(in), optional :: nSolution
+
+    integer :: info
+    integer :: nn, nrhs, lda, ldb
+    integer, allocatable :: ipiv(:)
+    character(len=100) :: error_string
+
+    lda = size(aa, dim=1)
+    if (present(nEquation)) then
+      @:ASSERT(nEquation >= 1 .and. nEquation <= lda)
+      nn = nEquation
+    else
+      nn = lda
+    end if
+    @:ASSERT(size(aa, dim=2) >= nn)
+
+    ldb = size(bb, dim=1)
+    @:ASSERT(ldb >= nn)
+    nrhs = size(bb, dim=2)
+    if (present(nSolution)) then
+      @:ASSERT(nSolution <= nrhs)
+      nrhs = nSolution
+    end if
+
+    info = 0
+    allocate(ipiv(nn))
+    call dgesv(nn, nrhs, aa, lda, ipiv, bb, ldb, info)
+
+    if (info /= 0) then
+      if (info < 0) then
+        write(error_string, "(A,I0)")'Failure in dgesv illegal argument at position : ', info
+      else
+        write(error_string, "(A,I0)")'Linear dependent system in dgesv,&
+            & info flag : ', info
+      end if
+      call error(error_string)
+    end if
+
+  end subroutine gesv_dble
+
 
   !> Double precision version of getrf.
   subroutine getrf_dble(aa, ipiv, nRow, nColumn, iError)

--- a/slateratom/lib/lapackroutines.F90
+++ b/slateratom/lib/lapackroutines.F90
@@ -4,9 +4,8 @@
 !! The interface of all LAPACK calls must be defined in the module lapack.
 module lapackroutines
 
-  use common_accuracy, only : dp, rdp
+  use common_accuracy, only : rdp
   use common_message, only : error
-  
   implicit none
 
   private
@@ -43,10 +42,10 @@ contains
   subroutine gesv_dble(aa, bb, nEquation, nSolution)
 
     !> Contains the coefficients on entry, the LU factorisation on exit.
-    real(dp), intent(inout) :: aa(:,:)
+    real(rdp), intent(inout) :: aa(:,:)
 
     !> Right hand side(s) of the linear equation on entry, solution(s) on exit.
-    real(dp), intent(inout) :: bb(:,:)
+    real(rdp), intent(inout) :: bb(:,:)
 
     !> The size of the problem (nr. of variables and equations). Must be only specified if different
     !> from size(aa, dim=1).

--- a/slateratom/lib/lapackroutines.F90
+++ b/slateratom/lib/lapackroutines.F90
@@ -225,4 +225,30 @@ contains
 
   end subroutine getrs1_dble
 
+  !> Solves overdetermined or underdetermined systems for GE matrices
+  ! subroutine dgelss_dble(amat, bmat, trans)
+
+  !   !> Matrix of the linear system
+  !   real(rdp), intent(inout) :: amat(:,:)
+
+  !   !>
+  !   real(rdp), intent(inout) :: bmat
+
+  !   !> Optional transpose (defaults to 'n')
+  !   character(len=1), intent(in), optional :: trans
+
+  !   !> Error flag, zero on successful exit
+  !   integer, intent(out), optional :: iError
+
+  !   integer :: nn, lda, info, lwork
+  !   real(rdp), allocatable :: work(:)
+  !   real(rdp) :: work2(1)
+    
+  !   integer :: info
+  !   allocate(svals(n), work(8*n))
+  !   call dgelss(n, n, 1, amat, size(amat,1), bmat, size(bmat,1), svals, 1.0e-10_dp, rank, work, 8*n, info)
+  !   if (info /= 0) call error("DIIS: dgelss failed to converge")
+  !     deallocate(svals, work)
+  ! end subroutine dgelss_dble
+
 end module lapackroutines

--- a/slateratom/lib/mixer.f90
+++ b/slateratom/lib/mixer.f90
@@ -4,6 +4,7 @@ module mixer
   use common_accuracy, only : dp
   use broydenmixer, only : TBroydenMixer, TBroydenMixer_mix, TBroydenMixer_reset
   use simplemixer, only : TSimpleMixer, TSimpleMixer_mix, TSimpleMixer_reset
+  use diismixer, only : TDiisMixer, TDiisMixer_init, TDiisMixer_mix, TDiisMixer_reset
   implicit none
 
   private
@@ -14,7 +15,7 @@ module mixer
   type TMixer
     private
 
-    !> Numerical type of mixer 1:2
+    !> Numerical type of mixer 1:3
     integer :: mixerType
 
     !> Simple mixer instance
@@ -23,6 +24,9 @@ module mixer
     !> Broyden mixer instance
     type(TBroydenMixer), allocatable :: pBroydenMixer
 
+    !> DIIS mixer instance
+    type(TDiisMixer), allocatable :: pDiisMixer
+
   end type TMixer
 
 
@@ -30,6 +34,7 @@ module mixer
   interface TMixer_init
     module procedure TMixer_initSimple
     module procedure TMixer_initBroyden
+    module procedure TMixer_initDiis
   end interface TMixer_init
 
 
@@ -43,6 +48,7 @@ module mixer
   type :: TMixerTypesEnum
     integer :: simple = 1
     integer :: broyden = 2
+    integer :: diis = 3
   end type TMixerTypesEnum
 
   !> Contains mixer types
@@ -81,6 +87,21 @@ contains
   end subroutine TMixer_initBroyden
 
 
+  !> Initializes a Broyden mixer.
+  subroutine TMixer_initDiis(this, pDiis)
+
+    !> Mixer instance
+    type(TMixer), intent(out) :: this
+
+    !> A valid Broyden mixer instance on exit
+    type(TDiisMixer), allocatable, intent(inout) :: pDiis
+
+    this%mixerType = mixerTypes%diis
+    call move_alloc(pDiis, this%pDiisMixer)
+
+  end subroutine TMixer_initDiis
+
+
   !> Returns mixer type as an int (1: simple, 2: Broyden)
   pure function TMixer_getMixerType(this) result(res)
     !> Mixer instance
@@ -107,6 +128,8 @@ contains
       call TSimpleMixer_reset(this%pSimpleMixer, nElem)
     case(mixerTypes%broyden)
       call TBroydenMixer_reset(this%pBroydenMixer, nElem)
+    case(mixerTypes%diis)
+      call TDiisMixer_reset(this%pDiisMixer, nElem)
     end select
 
   end subroutine TMixer_reset
@@ -129,6 +152,8 @@ contains
       call TSimpleMixer_mix(this%pSimpleMixer, inp, diff)
     case(mixerTypes%broyden)
       call TBroydenMixer_mix(this%pBroydenMixer, inp, diff)
+    case(mixerTypes%diis)
+      call TDiisMixer_mix(this%pDiisMixer, inp, diff)
     end select
 
   end subroutine TMixer_mix1D

--- a/slateratom/lib/mixer.f90
+++ b/slateratom/lib/mixer.f90
@@ -7,7 +7,7 @@ module mixer
   implicit none
 
   private
-  public :: TMixer, TMixer_init, TMixer_reset, TMixer_mix, mixerTypes
+  public :: TMixer, TMixer_init, TMixer_getMixerType, TMixer_reset, TMixer_mix, mixerTypes
 
 
   !> Interface type for mixers
@@ -79,6 +79,18 @@ contains
     call move_alloc(pBroyden, this%pBroydenMixer)
 
   end subroutine TMixer_initBroyden
+
+
+  !> Returns mixer type as an int (1: simple, 2: Broyden)
+  pure function TMixer_getMixerType(this) result(res)
+    !> Mixer instance
+    type(TMixer), intent(in) :: this
+
+    integer :: res
+
+    res = this%mixerType
+
+  end function
 
 
   !> Resets the mixer.

--- a/slateratom/lib/mixer.f90
+++ b/slateratom/lib/mixer.f90
@@ -136,7 +136,7 @@ contains
 
 
   !> Mixes two vectors.
-  subroutine TMixer_mix1D(this, inp, diff)
+  subroutine TMixer_mix1D(this, inp, diff, errvec)
 
     !> Mixer instance
     type(TMixer), intent(inout) :: this
@@ -147,20 +147,23 @@ contains
     !> Difference between input and output vectors (measure of lack of convergence)
     real(dp), intent(in) :: diff(:)
 
+    !> Error vector: measure of lack of convergence
+    real(dp), intent(in) :: errvec(:)
+
     select case (this%mixerType)
     case(mixerTypes%simple)
       call TSimpleMixer_mix(this%pSimpleMixer, inp, diff)
     case(mixerTypes%broyden)
       call TBroydenMixer_mix(this%pBroydenMixer, inp, diff)
     case(mixerTypes%diis)
-      call TDiisMixer_mix(this%pDiisMixer, inp, diff)
+      call TDiisMixer_mix(this%pDiisMixer, inp, diff, errvec)
     end select
 
   end subroutine TMixer_mix1D
 
 
   !> Mixes two 4D matrices.
-  subroutine TMixer_mix4D(this, inp, diff)
+  subroutine TMixer_mix4D(this, inp, diff, errvec)
 
     !> Mixer instance
     type(TMixer), intent(inout) :: this
@@ -168,8 +171,11 @@ contains
     !> Input vector on entry, result vector on exit
     real(dp), intent(inout), contiguous, target :: inp(:,0:,:,:)
 
-    !> Difference between input and output vectors (measure of lack of convergence)
+    !> Difference between input and output vectors
     real(dp), intent(in), contiguous, target :: diff(:,0:,:,:)
+
+    !> Error vector: measure of lack of convergence
+    real(dp), intent(in), contiguous, target :: errvec(:,0:,:,:)
 
     !! Difference between input and output vectors (1D pointer)
     real(dp), pointer :: pDiff(:)
@@ -177,10 +183,14 @@ contains
     !! Input vector on entry, result vector on exit (1D pointer)
     real(dp), pointer :: pInp(:)
 
+    !> Error vector: measure of lack of convergence (1D pointers)
+    real(dp), pointer :: pErrVec(:)
+
     pInp(1:size(inp)) => inp
     pDiff(1:size(diff)) => diff
+    pErrVec(1:size(diff)) => errvec
 
-    call TMixer_mix1D(this, pInp, pDiff)
+    call TMixer_mix1D(this, pInp, pDiff, pErrVec)
 
   end subroutine TMixer_mix4D
 

--- a/slateratom/lib/utilities.f90
+++ b/slateratom/lib/utilities.f90
@@ -6,7 +6,8 @@ module utilities
   implicit none
   private
 
-  public :: check_convergence, check_electron_number
+  public :: check_convergence_pot, check_electron_number, check_convergence_commutator,&
+      & check_convergence_spectrum, compute_commutator
   public :: vector_length, fak, zeroOutCpotOfEmptyDensitySpinChannels
 
 
@@ -32,8 +33,147 @@ contains
   end subroutine zeroOutCpotOfEmptyDensitySpinChannels
 
 
+  !> Compute the commutator [F,PS] in MO basis  
+  subroutine compute_commutator(max_l, num_alpha, poly_order, ff, pp, ss, invsqrt_ss, commutator)
+    !> maximum angular momentum
+    integer, intent(in) :: max_l
+
+    !> number of exponents in each shell
+    integer, intent(in) :: num_alpha(0:)
+
+    !> highest polynomial order + l in each shell
+    integer, intent(in) :: poly_order(0:)
+
+    !> Fock matrix
+    real(dp), intent(in) :: ff(:, 0:, :, :)
+
+    !> density matrix supervector
+    real(dp), intent(in) :: pp(:,0:,:,:)
+
+    !> overlap supervector
+    real(dp), intent(in) :: ss(0:,:,:)
+
+    !> inv. sqrt. of the overlap supervector
+    real(dp), intent(in) :: invsqrt_ss(0:,:,:)
+
+    !> commutator [F,PS]
+    real(dp), intent(out) :: commutator(:, 0:, :, :)
+
+    !! auxilliary variables
+    integer :: iSpin, ll
+
+    commutator(:, :, :, :) = 0.0_dp
+
+    ! Compute [F,PS] = FPS - SPF for each spin & ang. mom. block,
+    ! then orthogonalise like S^(-1/2) [F,PS] S^(-1/2)
+    do iSpin = 1, 2
+      do ll = 0, max_l
+        commutator(iSpin, ll, :, :) = &
+        & matmul(ff(iSpin, ll, :, :), matmul(pp(iSpin, ll, :, :), ss(ll, :, :)))&
+        & - matmul(matmul(ss(ll, :, :), pp(iSpin, ll, :, :)), ff(iSpin, ll, :, :))
+
+        commutator(iSpin, ll, :, :) = &
+        & matmul(invsqrt_ss(ll, :, :), matmul(commutator(iSpin, ll, :, :), invsqrt_ss(ll, :, :)))
+      end do
+    end do
+
+  end subroutine 
+
+
+  !> Check convergence by finding the maximum absolute value of the commutator [F,PS]
+  pure subroutine check_convergence_commutator(commutator, scftol, iScf, commutator_max,&
+      & tConverged)
+
+    !> commutator [F, PS]
+    real(dp), intent(in) :: commutator(:, 0:, :, :)
+
+    !> scf tolerance, i.e. convergence criteria
+    real(dp), intent(in) :: scftol
+
+    !> current SCF step
+    integer, intent(in) :: iScf
+
+    !> orbital gradient norm value
+    real(dp), intent(out) :: commutator_max
+
+    !> true, if SCF converged
+    logical, intent(out) :: tConverged
+
+    commutator_max = maxval(abs(commutator))
+
+    tConverged = commutator_max < scftol
+
+    if (iScf < 3) then
+      tConverged = .false.
+    end if
+
+  end subroutine check_convergence_commutator
+
+
+  !> Checks convergence by evaluating change in the occupied part of the eigenspectrum
+  pure subroutine check_convergence_spectrum(max_l, num_alpha, poly_order, eigval_new,&
+      & eigval_old, occ, scftol, iScf, res, tConverged)
+
+    !> maximum angular momentum
+    integer, intent(in) :: max_l
+
+    !> number of exponents in each shell
+    integer, intent(in) :: num_alpha(0:)
+  
+    !> highest polynomial order + l in each shell
+    integer, intent(in) :: poly_order(0:)
+
+    !> old and new eigenspectra to compare
+    real(dp), intent(in) :: eigval_new(:,0:,:), eigval_old(:,0:,:)
+
+    !> occupations
+    real(dp), intent(in) :: occ(:,0:,:)
+
+    !> scf tolerance, i.e. convergence criteria
+    real(dp), intent(in) :: scftol
+
+    !> current SCF step
+    integer, intent(in) :: iScf
+
+    !> obtained change
+    real(dp), intent(out) :: res
+
+    !> true, if SCF converged
+    logical, intent(out) :: tConverged
+
+    ! Loop indices
+    integer :: iSpin, ll, diagsize, ii
+
+    ! Difference
+    real(dp) :: diff
+
+    ! Max. difference, only occupied orbitals contribute
+    res = 0.0_dp
+    do iSpin = 1, 2
+      do ll = 0, max_l
+        diagsize = num_alpha(ll) * poly_order(ll)
+        do ii = 1, diagsize
+          if (occ(iSpin, ll, ii) > 1e-16) then
+            diff = abs(eigval_new(iSpin, ll, ii) - eigval_old(iSpin, ll, ii)) 
+            if (diff > res) then
+              res = diff
+            end if
+          end if
+        end do
+      end do
+    end do
+
+    tConverged = res < scftol
+
+    if (iScf < 3) then
+      tConverged = .false.
+    end if
+
+  end subroutine check_convergence_spectrum
+
+
   !> Checks SCF convergence by comparing new and old potential.
-  pure subroutine check_convergence(pot_old, pot_new, max_l, problemsize, scftol, iScf, change_max,&
+  pure subroutine check_convergence_pot(pot_old, pot_new, max_l, problemsize, scftol, iScf, change_max,&
       & tConverged)
 
     !> old and new potential to compare
@@ -82,7 +222,7 @@ contains
       tConverged = .false.
     end if
 
-  end subroutine check_convergence
+  end subroutine check_convergence_pot
 
 
   !> Checks conservation of electron number during SCF. If this fluctuates you are in deep trouble.

--- a/slateratom/prog/main.F90
+++ b/slateratom/prog/main.F90
@@ -176,7 +176,7 @@ program HFAtom
         & num_alpha, poly_order, problemsize, xcnr, num_mesh_points, weight, abcissa, vxc, alpha,&
         & pot_old, pot_new, commutator, tZora, ff, camAlpha, camBeta)
 
-    ! compute [F,PS]
+    ! compute S^(-1/2) [F,PS] S^(-1/2)
     call compute_commutator(max_l, num_alpha, poly_order, ff, pp, ss, invsqrt_ss, commutator)
 
     if (tZora) then

--- a/slateratom/prog/main.F90
+++ b/slateratom/prog/main.F90
@@ -188,14 +188,19 @@ program HFAtom
           & total_ene)
     end if
 
-    commutator_max = maxval(abs(commutator))
-    tCommutatorConverged = (maxval(abs(commutator)) < scftol)
     call check_convergence_pot(pot_old, pot_new, max_l, problemsize, scftol, iScf, d_pot_max,&
-        &tConverged)
+        & tConverged)
     call check_convergence_spectrum(max_l, num_alpha, poly_order, eigval, eigval_old, occ,&
         & scftol, iScf, d_spectrum_max, tSpectrumConverged)
+    commutator_max = maxval(abs(commutator))
+    tCommutatorConverged = (maxval(abs(commutator)) < scftol)
 
     write(*, '(I4,2X,3(1X,E16.9),3X,E16.9)') iScf, total_ene, d_spectrum_max, commutator_max, d_pot_max
+
+    ! In case of DIIS, use commutator instead of potential change for convergence
+    if (mixnr == 3) then
+      tConverged = tCommutatorConverged
+    end if
 
     ! if self-consistency is reached, exit loop
     if (tConverged) exit lpScf

--- a/slateratom/prog/main.F90
+++ b/slateratom/prog/main.F90
@@ -149,7 +149,7 @@ program HFAtom
   ! kinetic energy, nuclear-electron, and confinement matrix elements which are constant during SCF
   call build_hamiltonian(pMixer, 0, tt, uu, nuc, vconf_matrix, jj, kk, kk_lr, pp, max_l, num_alpha,&
       & poly_order, problemsize, xcnr, num_mesh_points, weight, abcissa, vxc, alpha, pot_old,&
-      & pot_new, commutator, tZora, ff, camAlpha, camBeta)
+      & pot_new, ss, invsqrt_ss, commutator, tZora, ff, camAlpha, camBeta)
 
   ! self-consistency cycles
   write(*,*) 'Energies in Hartree'
@@ -174,10 +174,7 @@ program HFAtom
     ! build Fock matrix and get total energy during SCF
     call build_hamiltonian(pMixer, iScf, tt, uu, nuc, vconf_matrix, jj, kk, kk_lr, pp, max_l,&
         & num_alpha, poly_order, problemsize, xcnr, num_mesh_points, weight, abcissa, vxc, alpha,&
-        & pot_old, pot_new, commutator, tZora, ff, camAlpha, camBeta)
-
-    ! compute S^(-1/2) [F,PS] S^(-1/2)
-    call compute_commutator(max_l, num_alpha, poly_order, ff, pp, ss, invsqrt_ss, commutator)
+        & pot_old, pot_new, ss, invsqrt_ss, commutator, tZora, ff, camAlpha, camBeta)
 
     if (tZora) then
       call getTotalEnergyZora(tt, uu, nuc, vconf_matrix, jj, kk, kk_lr, pp, max_l, num_alpha,&

--- a/slateratom/prog/main.F90
+++ b/slateratom/prog/main.F90
@@ -17,7 +17,8 @@ program HFAtom
       & write_waves_file_standard, write_wave_coeffs_file, cusp_values, writeAveragePotential
   use totalenergy, only : getTotalEnergy, getTotalEnergyZora
   use dft, only : check_accuracy, dft_start_pot, density_grid
-  use utilities, only : check_electron_number, check_convergence
+  use utilities, only : check_electron_number, check_convergence_pot, check_convergence_spectrum,&
+      & compute_commutator
   use zora_routines, only : scaled_zora
   use cmdargs, only : parse_command_arguments
   use common_poisson, only : TBeckeGridParams
@@ -94,6 +95,7 @@ program HFAtom
   ! build supervectors
   write(*, '(A)') 'Startup: Building Supervectors'
   call overlap(ss, max_l, num_alpha, alpha, poly_order)
+  
   call nuclear(uu, max_l, num_alpha, alpha, poly_order)
   call kinetic(tt, max_l, num_alpha, alpha, poly_order)
 
@@ -113,7 +115,7 @@ program HFAtom
   end if
 
   ! test for linear dependency
-  call diagonalize_overlap(max_l, num_alpha, poly_order, ss)
+  call diagonalize_overlap(max_l, num_alpha, poly_order, ss, invsqrt_ss)
 
   ! build supermatrices
   write(*, '(A)') 'Startup: Building Supermatrices'
@@ -147,15 +149,16 @@ program HFAtom
   ! kinetic energy, nuclear-electron, and confinement matrix elements which are constant during SCF
   call build_hamiltonian(pMixer, 0, tt, uu, nuc, vconf_matrix, jj, kk, kk_lr, pp, max_l, num_alpha,&
       & poly_order, problemsize, xcnr, num_mesh_points, weight, abcissa, vxc, alpha, pot_old,&
-      & pot_new, tZora, ff, camAlpha, camBeta)
+      & pot_new, commutator, tZora, ff, camAlpha, camBeta)
 
   ! self-consistency cycles
   write(*,*) 'Energies in Hartree'
   write(*,*)
-  write(*,*) ' Iter |   Total energy  |   HF-X energy  |   XC energy   |   Change in pot'
+  write(*,*) ' Iter |   Total energy  |  d(Spectrum)  |   d(Commutator)   |  d(Potential)'
   write(*,*) '--------------------------------------------------------------------------'
   lpScf: do iScf = 1, maxiter
 
+    eigval_old(:,:,:) = eigval
     pot_old(:,:,:,:) = pot_new
 
     ! diagonalize
@@ -171,7 +174,10 @@ program HFAtom
     ! build Fock matrix and get total energy during SCF
     call build_hamiltonian(pMixer, iScf, tt, uu, nuc, vconf_matrix, jj, kk, kk_lr, pp, max_l,&
         & num_alpha, poly_order, problemsize, xcnr, num_mesh_points, weight, abcissa, vxc, alpha,&
-        & pot_old, pot_new, tZora, ff, camAlpha, camBeta)
+        & pot_old, pot_new, commutator, tZora, ff, camAlpha, camBeta)
+
+    ! compute [F,PS]
+    call compute_commutator(max_l, num_alpha, poly_order, ff, pp, ss, invsqrt_ss, commutator)
 
     if (tZora) then
       call getTotalEnergyZora(tt, uu, nuc, vconf_matrix, jj, kk, kk_lr, pp, max_l, num_alpha,&
@@ -185,10 +191,14 @@ program HFAtom
           & total_ene)
     end if
 
-    call check_convergence(pot_old, pot_new, max_l, problemsize, scftol, iScf, change_max,&
-        & tConverged)
+    commutator_max = maxval(abs(commutator))
+    tCommutatorConverged = (maxval(abs(commutator)) < scftol)
+    call check_convergence_pot(pot_old, pot_new, max_l, problemsize, scftol, iScf, d_pot_max,&
+        &tConverged)
+    call check_convergence_spectrum(max_l, num_alpha, poly_order, eigval, eigval_old, occ,&
+        & scftol, iScf, d_spectrum_max, tSpectrumConverged)
 
-    write(*, '(I4,2X,3(1X,F16.9),3X,E16.9)') iScf, total_ene, exchange_energy, x_en_2, change_max
+    write(*, '(I4,2X,3(1X,E16.9),3X,E16.9)') iScf, total_ene, d_spectrum_max, commutator_max, d_pot_max
 
     ! if self-consistency is reached, exit loop
     if (tConverged) exit lpScf
@@ -233,7 +243,7 @@ program HFAtom
         & exchange_energy, x_en_2, conf_energy, total_ene)
   end if
 
-  write(*, '(A,E20.12)') 'Potential Matrix Elements converged to ', change_max
+  write(*, '(A,E20.12)') 'Potential Matrix Elements converged to ', d_pot_max
   write(*, '(A)') ' '
 
   if (tZora) then


### PR DESCRIPTION
This is another one from the old draft.

This PR adds two new diagnostic quantities to help track the SCF convergence: the occupied part of the eigenvalue spectrum and the orthogonalised [F,PS] commutator. The former helps to spot if the orbital energies (one quantity that goes directly into the SK files) are converging properly, the latter is just a popular convergence metric that is used by many quantum chemistry codes out there (Turbomole, for one), and thus its implementation would make direct comparison easier. None of the changes add new or alter existing functionality, but they are to help with further debugging whenever new extension to the code are made.

I'm not sure about the output format. In this PR, the new quantities take place of energy components in the output loop, like this:
```
  Iter |   Total energy  |  d(Spectrum)  |   d(Commutator)   |  d(Potential)
 --------------------------------------------------------------------------
   1   -0.457372080E+02  0.936361041E+01  0.698559924E+01    0.997865497E+01
  
   2   -0.542210337E+02  0.420185025E+01  0.138941972E+01    0.576569651E+00
  
   3   -0.544037238E+02  0.355577050E+00  0.565883699E+00    0.584803006E+00
  
   4   -0.544171921E+02  0.536017478E+00  0.136724190E+00    0.180180852E+00
  
   5   -0.544192146E+02  0.169040510E+00  0.828489182E-02    0.543483765E-02
  
...
```

I'm very welcome to your suggestions as to where to make them available instead of this.